### PR TITLE
Bungee: Implement getDefCommand & command unregistration

### DIFF
--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -26,13 +26,13 @@ package co.aikar.commands;
 import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
-import net.md_5.bungee.api.plugin.PluginManager;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -28,13 +28,11 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -96,6 +94,28 @@ public class BungeeCommandManager extends CommandManager<CommandSender, ChatColo
             }
             bungeeCommand.isRegistered = true;
             registeredCommands.put(commandName, bungeeCommand);
+        }
+    }
+
+    public void unregisterCommand(BaseCommand command) {
+        for (Map.Entry<String, RootCommand> entry : command.registeredCommands.entrySet()) {
+            String commandName = entry.getKey().toLowerCase();
+            BungeeRootCommand bungeeCommand = (BungeeRootCommand) entry.getValue();
+            if (bungeeCommand.isRegistered) {
+                unregisterCommand(bungeeCommand);
+            }
+            bungeeCommand.isRegistered = false;
+            registeredCommands.remove(commandName);
+        }
+    }
+
+    public void unregisterCommand(BungeeRootCommand command) {
+        this.plugin.getProxy().getPluginManager().unregisterCommand(command);
+    }
+
+    public void unregisterCommands() {
+        for (Map.Entry<String, BungeeRootCommand> entry : registeredCommands.entrySet()) {
+            unregisterCommand(entry.getValue());
         }
     }
 

--- a/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
@@ -85,4 +85,9 @@ public class BungeeRootCommand extends Command implements RootCommand, TabExecut
         this.children.forEach(child -> completions.addAll(child.tabComplete(sender, alias, args)));
         return new ArrayList<>(completions);
     }
+
+    @Override
+    public BaseCommand getDefCommand() {
+        return defCommand;
+    }
 }

--- a/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
@@ -29,7 +29,10 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
-import java.util.*;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
 
 public class BungeeRootCommand extends Command implements RootCommand, TabExecutor {
 


### PR DESCRIPTION
BungeeRootCommand did not have getDefCommand implemented, and thus Default commands were not being found and throwing NPE. This PR implements the method.

This PR also implements command unregistration through the Bungee API.