### PR TITLE
Fully unregister command by clearing the RegisteredCommand's subcommands

### DIFF
--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -103,6 +103,7 @@ public class BungeeCommandManager extends CommandManager<CommandSender, ChatColo
             BungeeRootCommand bungeeCommand = (BungeeRootCommand) entry.getValue();
             if (bungeeCommand.isRegistered) {
                 unregisterCommand(bungeeCommand);
+                bungeeCommand.getSubCommands().clear();
             }
             bungeeCommand.isRegistered = false;
             registeredCommands.remove(commandName);


### PR DESCRIPTION
Not sure how I feel about this. This does allow unregistration and re-registration by clearing the subcommands of the RegisteredCommand. Thoughts?