### PR TITLE
Added support for loading message bundles from other ClassLoaders, an…

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
@@ -48,6 +48,14 @@ public class BukkitLocales extends Locales {
         addMessageBundles("acf-minecraft", pluginName, pluginName.toLowerCase());
     }
 
+    @Override
+    public void addMessageBundle(String bundleName, Locale locale) {
+        // Load our bundles from the ClassLoader which ACF resides in
+        super.addMessageBundle(bundleName, locale);
+        // Attempt to load our bundles from the ClassLoader which the managers plugin resides in
+        this.addMessageBundle(this.manager.getPlugin().getClass().getClassLoader(), bundleName, locale);
+    }
+
     /**
      * Loads the given file
      * @param file

--- a/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
@@ -39,6 +39,7 @@ public class BukkitLocales extends Locales {
     public BukkitLocales(BukkitCommandManager manager) {
         super(manager);
         this.manager = manager;
+        this.addBundleClassLoader(this.manager.getPlugin().getClass().getClassLoader());
     }
 
     @Override
@@ -46,14 +47,6 @@ public class BukkitLocales extends Locales {
         super.loadLanguages();
         String pluginName = "acf-" + manager.plugin.getDescription().getName();
         addMessageBundles("acf-minecraft", pluginName, pluginName.toLowerCase());
-    }
-
-    @Override
-    public void addMessageBundle(String bundleName, Locale locale) {
-        // Load our bundles from the ClassLoader which ACF resides in
-        super.addMessageBundle(bundleName, locale);
-        // Attempt to load our bundles from the ClassLoader which the managers plugin resides in
-        this.addMessageBundle(this.manager.getPlugin().getClass().getClassLoader(), bundleName, locale);
     }
 
     /**

--- a/bungee/src/main/java/co/aikar/commands/BungeeLocales.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeLocales.java
@@ -1,5 +1,7 @@
 package co.aikar.commands;
 
+import java.util.Locale;
+
 public class BungeeLocales extends Locales {
     private final BungeeCommandManager manager;
 
@@ -14,5 +16,13 @@ public class BungeeLocales extends Locales {
         super.loadLanguages();
         String pluginName = "acf-" + manager.plugin.getDescription().getName();
         addMessageBundles("acf-minecraft", pluginName, pluginName.toLowerCase());
+    }
+
+    @Override
+    public void addMessageBundle(String bundleName, Locale locale) {
+        // Load our bundles from the ClassLoader which ACF resides in
+        super.addMessageBundle(bundleName, locale);
+        // Attempt to load our bundles from the ClassLoader which the managers plugin resides in
+        this.addMessageBundle(this.manager.getPlugin().getClass().getClassLoader(), bundleName, locale);
     }
 }

--- a/bungee/src/main/java/co/aikar/commands/BungeeLocales.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeLocales.java
@@ -1,7 +1,5 @@
 package co.aikar.commands;
 
-import java.util.Locale;
-
 public class BungeeLocales extends Locales {
     private final BungeeCommandManager manager;
 
@@ -9,6 +7,7 @@ public class BungeeLocales extends Locales {
         super(manager);
 
         this.manager = manager;
+        this.addBundleClassLoader(this.manager.getPlugin().getClass().getClassLoader());
     }
 
     @Override
@@ -16,13 +15,5 @@ public class BungeeLocales extends Locales {
         super.loadLanguages();
         String pluginName = "acf-" + manager.plugin.getDescription().getName();
         addMessageBundles("acf-minecraft", pluginName, pluginName.toLowerCase());
-    }
-
-    @Override
-    public void addMessageBundle(String bundleName, Locale locale) {
-        // Load our bundles from the ClassLoader which ACF resides in
-        super.addMessageBundle(bundleName, locale);
-        // Attempt to load our bundles from the ClassLoader which the managers plugin resides in
-        this.addMessageBundle(this.manager.getPlugin().getClass().getClassLoader(), bundleName, locale);
     }
 }

--- a/core/src/main/java/co/aikar/commands/Locales.java
+++ b/core/src/main/java/co/aikar/commands/Locales.java
@@ -118,9 +118,14 @@ public class Locales {
     }
 
     public void addMessageBundle(String bundleName, Locale locale) {
-        if (!loadedBundles.containsEntry(bundleName, locale)) {
-            loadedBundles.put(bundleName, locale);
-            this.localeManager.addMessageBundle(bundleName, locale);
+        this.addMessageBundle(this.getClass().getClassLoader(), bundleName, locale);
+    }
+
+    public void addMessageBundle(ClassLoader classLoader, String bundleName, Locale locale) {
+        if(!this.loadedBundles.containsEntry(bundleName, locale)) {
+            if(this.localeManager.addMessageBundle(classLoader, bundleName, locale)) {
+                this.loadedBundles.put(bundleName, locale);
+            }
         }
     }
 

--- a/sponge/src/main/java/co/aikar/commands/SpongeLocales.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeLocales.java
@@ -6,6 +6,7 @@ public class SpongeLocales extends Locales{
     public SpongeLocales(SpongeCommandManager manager) {
         super(manager);
         this.manager = manager;
+        this.addBundleClassLoader(this.manager.getPlugin().getClass().getClassLoader());
     }
 
     @Override


### PR DESCRIPTION
…d made the Bukkit & Bungee locales attempt to load from the ClassLoader that ACF is apart of, and the ClassLoader that the CommandManagers plugin belongs to.

Basically gives support for my pull request in locales (https://github.com/aikar/locales/pull/2), and makes it so Bukkit/Bungee plugins search not only in the direct ClassLoader that ACF is apart of, but also the ClassLoader that the CommandManagers plugin instance is located.