### PR TITLE
Added the autoDetectFromClient feature for Bukkit languages, it will …

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
@@ -50,8 +50,13 @@ class ACFBukkitListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        manager.readPlayerLocale(player);
-        this.plugin.getServer().getScheduler().runTaskLater(this.plugin, () -> manager.readPlayerLocale(player), 20);
+        if(this.manager.autoDetectFromClient) {
+            this.manager.readPlayerLocale(player);
+            this.plugin.getServer().getScheduler().runTaskLater(this.plugin, () -> manager.readPlayerLocale(player), 20);
+        } else {
+            this.manager.setPlayerLocale(player, this.manager.getLocales().getDefaultLocale());
+            this.manager.notifyLocaleChange(this.manager.getCommandIssuer(player), null, this.manager.getLocales().getDefaultLocale());
+        }
     }
 
     @EventHandler

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -79,6 +79,7 @@ public class BukkitCommandManager extends CommandManager<
     MCTiming commandTiming;
     protected BukkitLocales locales;
     private boolean cantReadLocale = false;
+    protected boolean autoDetectFromClient = true;
     protected Map<UUID, Locale> issuersLocale = Maps.newConcurrentMap();
 
     @SuppressWarnings("JavaReflectionMemberAccess")
@@ -95,7 +96,7 @@ public class BukkitCommandManager extends CommandManager<
         Bukkit.getPluginManager().registerEvents(new ACFBukkitListener(this, plugin), plugin);
         getLocales(); // auto load locales
         this.localeTask = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
-            if (cantReadLocale) {
+            if (this.cantReadLocale || !this.autoDetectFromClient) {
                 return;
             }
             Bukkit.getOnlinePlayers().forEach(this::readPlayerLocale);
@@ -358,5 +359,12 @@ public class BukkitCommandManager extends CommandManager<
             }
         }
         return super.getIssuerLocale(issuer);
+    }
+
+    public boolean usePerIssuerLocale(boolean usePerIssuerLocale, boolean autoDetectFromClient) {
+        boolean old = this.usePerIssuerLocale;
+        this.usePerIssuerLocale = usePerIssuerLocale;
+        this.autoDetectFromClient = autoDetectFromClient;
+        return old;
     }
 }


### PR DESCRIPTION
…disable the automated language detection system.

At the title states, I've added a feature inside the BukkitCommandManager to disable/enable the detection system for the language that a users game client is using.