### PR TITLE
Add support for per issuer locale in Sponge and BungeeCord

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
@@ -54,7 +54,7 @@ class ACFBukkitListener implements Listener {
             this.manager.readPlayerLocale(player);
             this.plugin.getServer().getScheduler().runTaskLater(this.plugin, () -> manager.readPlayerLocale(player), 20);
         } else {
-            this.manager.setPlayerLocale(player, this.manager.getLocales().getDefaultLocale());
+            this.manager.setIssuerLocale(player, this.manager.getLocales().getDefaultLocale());
             this.manager.notifyLocaleChange(this.manager.getCommandIssuer(player), null, this.manager.getLocales().getDefaultLocale());
         }
     }

--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitListener.java
@@ -60,7 +60,8 @@ class ACFBukkitListener implements Listener {
     }
 
     @EventHandler
-    public void onPlayerJoin(PlayerQuitEvent event) {
-        manager.issuersLocale.remove(event.getPlayer().getUniqueId());
+    public void onPlayerQuit(PlayerQuitEvent quitEvent) {
+        //cleanup
+        manager.issuersLocale.remove(quitEvent.getPlayer().getUniqueId());
     }
 }

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
@@ -23,11 +23,12 @@
 
 package co.aikar.commands;
 
-import org.bukkit.entity.Player;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 public class BukkitCommandIssuer implements CommandIssuer {
@@ -55,12 +56,13 @@ public class BukkitCommandIssuer implements CommandIssuer {
     }
 
     @Override
-    public Optional<UUID> getUniqueId() {
+    public @NotNull UUID getUniqueId() {
         if (isPlayer()) {
-            return Optional.of(((Player) sender).getUniqueId());
+            return ((Player) sender).getUniqueId();
         }
 
-        return Optional.empty();
+        //generate a unique id based of the name (like for the console command sender)
+        return UUID.nameUUIDFromBytes(sender.getName().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
@@ -23,10 +23,12 @@
 
 package co.aikar.commands;
 
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 public class BukkitCommandIssuer implements CommandIssuer {
     private final BukkitCommandManager manager;
@@ -50,6 +52,15 @@ public class BukkitCommandIssuer implements CommandIssuer {
 
     public Player getPlayer() {
         return isPlayer() ? (Player) sender : null;
+    }
+
+    @Override
+    public Optional<UUID> getUniqueId() {
+        if (isPlayer()) {
+            return Optional.of(((Player) sender).getUniqueId());
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -26,7 +26,6 @@ package co.aikar.commands;
 import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
 import co.aikar.timings.lib.MCTiming;
 import co.aikar.timings.lib.TimingManager;
-import com.google.common.collect.Maps;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
@@ -52,7 +51,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -80,7 +78,6 @@ public class BukkitCommandManager extends CommandManager<
     protected BukkitLocales locales;
     private boolean cantReadLocale = false;
     protected boolean autoDetectFromClient = true;
-    protected Map<UUID, Locale> issuersLocale = Maps.newConcurrentMap();
 
     @SuppressWarnings("JavaReflectionMemberAccess")
     public BukkitCommandManager(Plugin plugin) {
@@ -93,7 +90,9 @@ public class BukkitCommandManager extends CommandManager<
         this.formatters.put(MessageType.SYNTAX, new BukkitMessageFormatter(ChatColor.YELLOW, ChatColor.GREEN, ChatColor.WHITE));
         this.formatters.put(MessageType.INFO, new BukkitMessageFormatter(ChatColor.BLUE, ChatColor.DARK_GREEN, ChatColor.GREEN));
         this.formatters.put(MessageType.HELP, new BukkitMessageFormatter(ChatColor.AQUA, ChatColor.GREEN, ChatColor.YELLOW));
+
         Bukkit.getPluginManager().registerEvents(new ACFBukkitListener(this, plugin), plugin);
+
         getLocales(); // auto load locales
         this.localeTask = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
             if (this.cantReadLocale || !this.autoDetectFromClient) {
@@ -339,26 +338,6 @@ public class BukkitCommandManager extends CommandManager<
                 logger.log(logLevel, LogLevel.LOG_PREFIX + line);
             }
         }
-    }
-
-    public Locale setPlayerLocale(Player player, Locale locale) {
-        Locale old = this.issuersLocale.put(player.getUniqueId(), locale);
-        if (!Objects.equals(old, locale)) {
-            this.notifyLocaleChange(getCommandIssuer(player), old, locale);
-        }
-        return old;
-    }
-
-    @Override
-    public Locale getIssuerLocale(CommandIssuer issuer) {
-        if (usingPerIssuerLocale() && issuer.getIssuer() instanceof Player) {
-            UUID uniqueId = ((Player) issuer.getIssuer()).getUniqueId();
-            Locale locale = issuersLocale.get(uniqueId);
-            if (locale != null) {
-                return locale;
-            }
-        }
-        return super.getIssuerLocale(issuer);
     }
 
     public boolean usePerIssuerLocale(boolean usePerIssuerLocale, boolean autoDetectFromClient) {

--- a/bungee/src/main/java/co/aikar/commands/ACFBungeeListener.java
+++ b/bungee/src/main/java/co/aikar/commands/ACFBungeeListener.java
@@ -1,0 +1,37 @@
+package co.aikar.commands;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
+import net.md_5.bungee.api.event.PostLoginEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.event.EventHandler;
+
+import java.util.concurrent.TimeUnit;
+
+public class ACFBungeeListener implements Listener {
+
+    private final BungeeCommandManager manager;
+    private final Plugin plugin;
+
+    public ACFBungeeListener(BungeeCommandManager manager, Plugin plugin) {
+        this.manager = manager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PostLoginEvent loginEvent) {
+        ProxiedPlayer player = loginEvent.getPlayer();
+
+        //the client settings are sent after a successful login
+        Runnable task = () -> manager.readLocale(player);
+        plugin.getProxy().getScheduler().schedule(plugin, task, 1, TimeUnit.SECONDS);
+    }
+
+    @EventHandler
+    public void onDisconnect(PlayerDisconnectEvent disconnectEvent) {
+        //cleanup
+        ProxiedPlayer player = disconnectEvent.getPlayer();
+        manager.issuersLocale.remove(player.getUniqueId());
+    }
+}

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandIssuer.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandIssuer.java
@@ -27,6 +27,8 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 public class BungeeCommandIssuer implements CommandIssuer {
     private final BungeeCommandManager manager;
@@ -55,6 +57,15 @@ public class BungeeCommandIssuer implements CommandIssuer {
     @Override
     public boolean isPlayer() {
         return sender instanceof ProxiedPlayer;
+    }
+
+    @Override
+    public Optional<UUID> getUniqueId() {
+        if (isPlayer()) {
+            return Optional.of(((ProxiedPlayer) sender).getUniqueId());
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandIssuer.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandIssuer.java
@@ -25,9 +25,10 @@ package co.aikar.commands;
 
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 public class BungeeCommandIssuer implements CommandIssuer {
@@ -60,12 +61,13 @@ public class BungeeCommandIssuer implements CommandIssuer {
     }
 
     @Override
-    public Optional<UUID> getUniqueId() {
+    public @NotNull UUID getUniqueId() {
         if (isPlayer()) {
-            return Optional.of(((ProxiedPlayer) sender).getUniqueId());
+            return ((ProxiedPlayer) sender).getUniqueId();
         }
 
-        return Optional.empty();
+        //generate a unique id based of the name (like for the console command sender)
+        return UUID.nameUUIDFromBytes(sender.getName().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -113,7 +113,7 @@ public class BungeeCommandManager extends CommandManager<
         //This can be null if we didn't received a settings packet
         Locale locale = player.getLocale();
         if (locale != null) {
-            setPlayerLocale(player, player.getLocale());
+            setIssuerLocale(player, player.getLocale());
         }
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandIssuer.java
+++ b/core/src/main/java/co/aikar/commands/CommandIssuer.java
@@ -25,8 +25,8 @@ package co.aikar.commands;
 
 import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface CommandIssuer {
@@ -54,9 +54,9 @@ public interface CommandIssuer {
     }
 
     /**
-     * @return the UUID of that player or Optional.empty() if it's not a player
+     * @return the unique id of that issuer
      */
-    Optional<UUID> getUniqueId();
+    @NotNull UUID getUniqueId();
 
     /**
      * Has permission node

--- a/core/src/main/java/co/aikar/commands/CommandIssuer.java
+++ b/core/src/main/java/co/aikar/commands/CommandIssuer.java
@@ -26,6 +26,9 @@ package co.aikar.commands;
 import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface CommandIssuer {
     /**
      * Gets the issuer in the platforms native object
@@ -49,6 +52,11 @@ public interface CommandIssuer {
     default void sendMessage(String message) {
         getManager().sendMessage(this, MessageType.INFO, MessageKeys.INFO_MESSAGE, "{message}", message);
     }
+
+    /**
+     * @return the UUID of that player or Optional.empty() if it's not a player
+     */
+    Optional<UUID> getUniqueId();
 
     /**
      * Has permission node

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -27,6 +27,7 @@ import co.aikar.commands.annotation.Dependency;
 import co.aikar.locales.MessageKeyProvider;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import org.jetbrains.annotations.NotNull;
@@ -35,14 +36,16 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
+import java.util.UUID;
 
 @SuppressWarnings("WeakerAccess")
 public abstract class CommandManager <
@@ -75,6 +78,8 @@ public abstract class CommandManager <
     protected Map<MessageType, MF> formatters = new IdentityHashMap<>();
     protected MF defaultFormatter;
     protected int defaultHelpPerPage = 10;
+
+    protected Map<UUID, Locale> issuersLocale = Maps.newConcurrentMap();
 
     private Set<String> unstableAPIs = Sets.newHashSet();
 
@@ -344,7 +349,32 @@ public abstract class CommandManager <
         });
     }
 
+    public Locale setPlayerLocale(IT player, Locale locale) {
+        I commandIssuer = getCommandIssuer(player);
+        Optional<UUID> uniqueId = commandIssuer.getUniqueId();
+
+        if (uniqueId.isPresent()) {
+            Locale old = issuersLocale.put(uniqueId.get(), locale);
+            if (!Objects.equals(old, locale)) {
+                this.notifyLocaleChange(commandIssuer, old, locale);
+            }
+
+            return old;
+        }
+
+        throw new IllegalArgumentException("The argument " + player + " doesn't implement getUniqueId. We can only " +
+                "set the locale for player objects");
+    }
+
     public Locale getIssuerLocale(CommandIssuer issuer) {
+        Optional<UUID> uniqueId = issuer.getUniqueId();
+        if (usingPerIssuerLocale() && uniqueId.isPresent()) {
+            Locale locale = issuersLocale.get(uniqueId.get());
+            if (locale != null) {
+                return locale;
+            }
+        }
+
         return getLocales().getDefaultLocale();
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -349,8 +349,8 @@ public abstract class CommandManager <
         });
     }
 
-    public Locale setPlayerLocale(IT player, Locale locale) {
-        I commandIssuer = getCommandIssuer(player);
+    public Locale setIssuerLocale(IT issuer, Locale locale) {
+        I commandIssuer = getCommandIssuer(issuer);
 
         Locale old = issuersLocale.put(commandIssuer.getUniqueId(), locale);
         if (!Objects.equals(old, locale)) {

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -42,10 +42,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.UUID;
+
 
 @SuppressWarnings("WeakerAccess")
 public abstract class CommandManager <
@@ -351,25 +351,18 @@ public abstract class CommandManager <
 
     public Locale setPlayerLocale(IT player, Locale locale) {
         I commandIssuer = getCommandIssuer(player);
-        Optional<UUID> uniqueId = commandIssuer.getUniqueId();
 
-        if (uniqueId.isPresent()) {
-            Locale old = issuersLocale.put(uniqueId.get(), locale);
-            if (!Objects.equals(old, locale)) {
-                this.notifyLocaleChange(commandIssuer, old, locale);
-            }
-
-            return old;
+        Locale old = issuersLocale.put(commandIssuer.getUniqueId(), locale);
+        if (!Objects.equals(old, locale)) {
+            this.notifyLocaleChange(commandIssuer, old, locale);
         }
 
-        throw new IllegalArgumentException("The argument " + player + " doesn't implement getUniqueId. We can only " +
-                "set the locale for player objects");
+        return old;
     }
 
     public Locale getIssuerLocale(CommandIssuer issuer) {
-        Optional<UUID> uniqueId = issuer.getUniqueId();
-        if (usingPerIssuerLocale() && uniqueId.isPresent()) {
-            Locale locale = issuersLocale.get(uniqueId.get());
+        if (usingPerIssuerLocale()) {
+            Locale locale = issuersLocale.get(issuer.getUniqueId());
             if (locale != null) {
                 return locale;
             }

--- a/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
@@ -3,8 +3,8 @@ package co.aikar.commands;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageEmbed;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public class JDACommandEvent implements CommandIssuer {
@@ -38,8 +38,11 @@ public class JDACommandEvent implements CommandIssuer {
     }
 
     @Override
-    public Optional<UUID> getUniqueId() {
-        return Optional.empty();
+    public @NotNull UUID getUniqueId() {
+        // Discord id only have 64 bit width (long) while UUIDs have twice the size.
+        // In order to keep it unique we use 0L for the first 64 bit.
+        long authorId = event.getAuthor().getIdLong();
+        return new UUID(0, authorId);
     }
 
     @Override

--- a/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
@@ -4,6 +4,9 @@ import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageEmbed;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public class JDACommandEvent implements CommandIssuer {
 
     private MessageReceivedEvent event;
@@ -32,6 +35,11 @@ public class JDACommandEvent implements CommandIssuer {
     @Override
     public boolean isPlayer() {
         return false;
+    }
+
+    @Override
+    public Optional<UUID> getUniqueId() {
+        return Optional.empty();
     }
 
     @Override

--- a/sponge/src/main/java/co/aikar/commands/ACFSpongeListener.java
+++ b/sponge/src/main/java/co/aikar/commands/ACFSpongeListener.java
@@ -1,0 +1,28 @@
+package co.aikar.commands;
+
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.entity.living.humanoid.player.PlayerChangeClientSettingsEvent;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+
+public class ACFSpongeListener {
+
+    private final SpongeCommandManager manager;
+
+    public ACFSpongeListener(SpongeCommandManager manager) {
+        this.manager = manager;
+    }
+
+    @Listener(order = Order.POST)
+    public void onSettingsChange(PlayerChangeClientSettingsEvent changeSettingsEvent, @First Player targetPlayer) {
+        //this event will be fired on join as well as every time the player changes it
+        manager.setPlayerLocale(targetPlayer, targetPlayer.getLocale());
+    }
+
+    @Listener
+    public void onDisconnectCleanup(ClientConnectionEvent.Disconnect disconnectEvent, @First Player player) {
+        manager.issuersLocale.remove(player.getUniqueId());
+    }
+}

--- a/sponge/src/main/java/co/aikar/commands/ACFSpongeListener.java
+++ b/sponge/src/main/java/co/aikar/commands/ACFSpongeListener.java
@@ -18,7 +18,7 @@ public class ACFSpongeListener {
     @Listener(order = Order.POST)
     public void onSettingsChange(PlayerChangeClientSettingsEvent changeSettingsEvent, @First Player targetPlayer) {
         //this event will be fired on join as well as every time the player changes it
-        manager.setPlayerLocale(targetPlayer, targetPlayer.getLocale());
+        manager.setIssuerLocale(targetPlayer, targetPlayer.getLocale());
     }
 
     @Listener

--- a/sponge/src/main/java/co/aikar/commands/SpongeCommandIssuer.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeCommandIssuer.java
@@ -26,8 +26,11 @@ package co.aikar.commands;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.serializer.TextSerializers;
+import org.spongepowered.api.util.Identifiable;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 public class SpongeCommandIssuer implements CommandIssuer {
 
@@ -49,6 +52,15 @@ public class SpongeCommandIssuer implements CommandIssuer {
         return this.source;
     }
 
+    @Override
+    public Optional<UUID> getUniqueId() {
+        if (isPlayer()) {
+            return Optional.of(((Identifiable) source).getUniqueId());
+        }
+
+        return Optional.empty();
+    }
+
     public Player getPlayer() {
         return isPlayer() ? (Player) source : null;
     }
@@ -67,7 +79,6 @@ public class SpongeCommandIssuer implements CommandIssuer {
     public boolean hasPermission(final String permission) {
         return this.source.hasPermission(permission);
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/sponge/src/main/java/co/aikar/commands/SpongeCommandIssuer.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeCommandIssuer.java
@@ -23,13 +23,14 @@
 
 package co.aikar.commands;
 
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.util.Identifiable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 public class SpongeCommandIssuer implements CommandIssuer {
@@ -53,12 +54,13 @@ public class SpongeCommandIssuer implements CommandIssuer {
     }
 
     @Override
-    public Optional<UUID> getUniqueId() {
+    public @NotNull UUID getUniqueId() {
         if (isPlayer()) {
-            return Optional.of(((Identifiable) source).getUniqueId());
+            return ((Identifiable) source).getUniqueId();
         }
 
-        return Optional.empty();
+        //generate a unique id based of the name (like for the console command sender)
+        return UUID.nameUUIDFromBytes(source.getName().getBytes(StandardCharsets.UTF_8));
     }
 
     public Player getPlayer() {

--- a/sponge/src/main/java/co/aikar/commands/SpongeCommandManager.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeCommandManager.java
@@ -68,6 +68,8 @@ public class SpongeCommandManager extends CommandManager<
         this.formatters.put(MessageType.HELP, new SpongeMessageFormatter(TextColors.AQUA, TextColors.GREEN, TextColors.YELLOW));
         getLocales(); // auto load locales
 
+        Sponge.getEventManager().registerListeners(plugin, new ACFSpongeListener(this));
+
         //TODO more default dependencies for sponge
         registerDependency(plugin.getClass(), plugin);
     }
@@ -196,5 +198,4 @@ public class SpongeCommandManager extends CommandManager<
     public SpongeConditionContext createConditionContext(CommandIssuer issuer, String config) {
         return new SpongeConditionContext((SpongeCommandIssuer) issuer, config);
     }
-
 }


### PR DESCRIPTION
This adds the missing support for issuer locales in Sponge and BungeeCord.

I'm open for feedback. Here is a short summary.
* Added update task and delayed join listener in BungeeCord
    * Similar to the implementation in Bukkit but without reflection
* Added settings change listener in Sponge
    * No task needed. It fires an event every time the players changes the settings
* Moved setLocale method up to the CommandManager to remove the amount of duplicated code
    * Sponge, Bukkit and BungeeCord would have a similar implementation only the UUID call is different. (See below)
    * The Discord implementation doesn't uses it and will always use the fallback locale.
* Added Optional<UUID> getUniqueId to CommandIssuer. 
    * Do you think `@Nullable` is better?
    * Or should we add another generic in CommandManager for player objects, but what should we do then in Discord which doesn't have player classes.
    * Discord only has `long` ids. So it currently returns `Optional.empty()`