### PR TITLE
[Draft] Help improvements: detailed param help, headers...

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandContexts.java
+++ b/core/src/main/java/co/aikar/commands/CommandContexts.java
@@ -232,6 +232,15 @@ public class CommandContexts <R extends CommandExecutionContext<?, ? extends Com
             if (perPage != null) {
                 commandHelp.setPerPage(perPage);
             }
+
+            // check if we have an exact match and should display the help page for that sub command instead
+            if(search != null){
+                String cmd = String.join(" ", search);
+                if(commandHelp.isExactMatch(cmd)){
+                    return commandHelp;
+                }
+            }
+
             commandHelp.setSearch(search);
             return commandHelp;
         });

--- a/core/src/main/java/co/aikar/commands/CommandHelpFormatter.java
+++ b/core/src/main/java/co/aikar/commands/CommandHelpFormatter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CommandHelpFormatter {
+
+    private final CommandManager manager;
+
+    public CommandHelpFormatter(CommandManager manager) {
+        this.manager = manager;
+    }
+
+    // ########
+    // # help #
+    // ########
+
+    public void printHelpHeader(CommandIssuer issuer, String commandName, int page, int totalPages, int totalResults) {
+        issuer.sendMessage(MessageType.HELP, MessageKeys.HELP_HEADER, "{command}", commandName);
+    }
+
+    public void printHelpLine(CommandIssuer issuer, String commandName, HelpEntry page) {
+        String formatted = this.manager.formatMessage(issuer, MessageType.HELP, MessageKeys.HELP_FORMAT, getFormatReplacements(page));
+        for (String msg : ACFPatterns.NEWLINE.split(formatted)) {
+            issuer.sendMessageInternal(ACFUtil.rtrim(msg));
+        }
+    }
+
+    public void printHelpFooter(CommandIssuer issuer, String commandName, int page, int totalPages, int totalResults, boolean lastPage) {
+        if(lastPage)return;
+        issuer.sendMessage(MessageType.HELP, MessageKeys.HELP_PAGE_INFORMATION,
+                "{page}", "" + page,
+                "{totalpages}", ""+ totalPages,
+                "{results}", "" + totalResults
+        );
+    }
+
+    // ##########
+    // # search #
+    // ##########
+
+    public void printSearchHeader(CommandIssuer issuer, String commandName, int page, int totalPages, int totalResults, List<String> search) {
+        issuer.sendMessage(MessageType.HELP, MessageKeys.HELP_SEARCH_HEADER,
+                "{command}", commandName,
+                "{search}", String.join(" ", search));
+    }
+
+    public void printSearchLine(CommandIssuer issuer, String commandName, HelpEntry page, int score) {
+        String formatted = this.manager.formatMessage(issuer, MessageType.HELP, MessageKeys.HELP_FORMAT, getFormatReplacements(page));
+        for (String msg : ACFPatterns.NEWLINE.split(formatted)) {
+            issuer.sendMessageInternal(ACFUtil.rtrim(msg));
+        }
+    }
+
+    public void printSearchFooter(CommandIssuer issuer, String commandName, int page, int totalPages, int totalResults, List<String> search, boolean lastPage) {
+        if(lastPage)return;
+        issuer.sendMessage(MessageType.HELP, MessageKeys.HELP_PAGE_INFORMATION,
+                "{page}", "" + page,
+                "{totalpages}", ""+ totalPages,
+                "{results}", "" + totalResults
+        );
+    }
+
+    // ############
+    // # detailed #
+    // ############
+
+    public void printDetailedHelpHeader(CommandIssuer issuer, String commandName, HelpEntry page) {
+        issuer.sendMessage(MessageType.HELP, MessageKeys.HELP_DETAILED_HEADER, "{command}", page.getCommand());
+    }
+
+    public void printDetailedHelpLine(CommandIssuer issuer, String commandName, HelpEntry page, String subCommand, String paramDescription) {
+        String formattedMsg = this.manager.formatMessage(issuer, MessageType.HELP, MessageKeys.HELP_DETAILED_FORMAT, getDetailedFormatReplacements(subCommand, paramDescription, page));
+        for (String msg : ACFPatterns.NEWLINE.split(formattedMsg)) {
+            issuer.sendMessageInternal(ACFUtil.rtrim(msg));
+        }
+    }
+
+    public void printDetailedHelpFooter(CommandIssuer issuer, String commandName, HelpEntry page) {
+        // default doesn't have a footer
+    }
+
+    /**
+     * Override this to control replacements
+     * @param e
+     * @return
+     */
+    @NotNull
+    public String[] getFormatReplacements(HelpEntry e) {
+        //{command} {parameters} {separator} {description}
+        return new String[] {
+                "{command}", e.getCommand(),
+                "{parameters}", e.getParameterSyntax(),
+                "{separator}", e.getDescription().isEmpty() ? "" : "-",
+                "{description}", e.getDescription()
+        };
+    }
+
+    /**
+     * Override this to control replacements
+     * @param cmd
+     * @param help
+     * @param page
+     * @return
+     */
+    @NotNull
+    public String[] getDetailedFormatReplacements(String cmd, String help, HelpEntry page) {
+        //{name} {description}
+        return new String[] {
+                "{name}", cmd,
+                "{description}", help
+        };
+    }
+}

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -71,6 +71,7 @@ public abstract class CommandManager <
     protected final CommandConditions<I, CEC, CC> conditions = new CommandConditions<>(this);
     protected ExceptionHandler defaultExceptionHandler = null;
     protected Table<Class<?>, String, Object> dependencies = HashBasedTable.create();
+    protected CommandHelpFormatter helpFormatter = new CommandHelpFormatter(this);
 
     protected boolean usePerIssuerLocale = false;
     protected List<IssuerLocaleChangedCallback<I>> localeChangedCallbacks = Lists.newArrayList();
@@ -184,6 +185,15 @@ public abstract class CommandManager <
     public void setDefaultHelpPerPage(int defaultHelpPerPage) {
         verifyUnstableAPI("help");
         this.defaultHelpPerPage = defaultHelpPerPage;
+    }
+    /** @deprecated Unstable API */ @Deprecated @UnstableAPI
+    public void setHelpFormatter(CommandHelpFormatter helpFormatter) {
+        this.helpFormatter = helpFormatter;
+    }
+
+    /** @deprecated Unstable API */ @Deprecated @UnstableAPI
+    public CommandHelpFormatter getHelpFormatter() {
+        return helpFormatter;
     }
 
     /**

--- a/core/src/main/java/co/aikar/commands/HelpEntry.java
+++ b/core/src/main/java/co/aikar/commands/HelpEntry.java
@@ -23,24 +23,39 @@
 
 package co.aikar.commands;
 
+import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.HelpSearchTags;
+
+import java.lang.reflect.Parameter;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class HelpEntry {
 
     private final RegisteredCommand command;
     private final String searchTags;
     private int searchScore = 1;
+    private Map<String, String> parameters = new LinkedHashMap<>();
 
     HelpEntry(RegisteredCommand command) {
         this.command = command;
         HelpSearchTags tagsAnno = command.method.getAnnotation(HelpSearchTags.class);
         this.searchTags = tagsAnno != null ? tagsAnno.value() : null;
+
+        // search for parameter descriptions
+        for (Parameter parameter : command.method.getParameters()) {
+            Description description = parameter.getAnnotation(Description.class);
+            if(description != null){
+                parameters.put(parameter.getName(), description.value());
+            }else{
+                //TODO also add parameters with not description?
+            }
+        }
     }
 
     RegisteredCommand getRegisteredCommand() {
         return this.command;
     }
-
 
     public String getCommand(){
         return "/" + this.command.command;
@@ -68,5 +83,9 @@ public class HelpEntry {
 
     public String getSearchTags() {
         return searchTags;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
     }
 }

--- a/core/src/main/java/co/aikar/commands/MessageKeys.java
+++ b/core/src/main/java/co/aikar/commands/MessageKeys.java
@@ -45,10 +45,14 @@ public enum MessageKeys implements MessageKeyProvider {
     PLEASE_SPECIFY_AT_MOST,
     NOT_ALLOWED_ON_CONSOLE,
     COULD_NOT_FIND_PLAYER,
-    HELP_FORMAT,
     NO_COMMAND_MATCHED_SEARCH,
     HELP_PAGE_INFORMATION,
-    HELP_NO_RESULTS
+    HELP_NO_RESULTS,
+    HELP_HEADER,
+    HELP_FORMAT,
+    HELP_DETAILED_HEADER,
+    HELP_DETAILED_FORMAT,
+    HELP_SEARCH_HEADER,
     ;
 
     private final MessageKey key = MessageKey.of("acf-core." + this.name().toLowerCase());

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -28,6 +28,7 @@ import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Syntax;
 import co.aikar.commands.annotation.Values;
@@ -105,11 +106,23 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
             if (resolver != null) {
                 resolvers[i] = resolver;
 
-                if (!scope.manager.isCommandIssuer(type)) {
+                Flags flags = parameter.getAnnotation(Flags.class);
+                // check if type is a command issuer and actually the sender of this command
+                if (!scope.manager.isCommandIssuer(type) || (flags != null && flags.value().equals("other"))) {
                     String name = parameter.getName();
                     if (isOptionalResolver(resolver, parameter)) {
-                        optionalResolvers++;
-                        if (!(resolver instanceof IssuerOnlyContextResolver)) {
+                        if(resolver instanceof  IssuerAwareContextResolver){
+                            // if its a issuer, but he has the other flag, its actually not an optional resolver!
+                            if(flags != null && flags.value().equals("other")){
+                                requiredResolvers++;
+                                syntaxB.append('<').append(name).append("> ");
+                            }else{
+                                // optional issuer aware context resolver
+                                optionalResolvers++;
+                            }
+                        }else{
+                            // some other optional resolver
+                            optionalResolvers++;
                             syntaxB.append('[').append(name).append("] ");
                         }
                     } else {

--- a/languages/core/acf-core_en.properties
+++ b/languages/core/acf-core_en.properties
@@ -34,7 +34,11 @@ acf-core.must_be_max_length = Error: Must be at most {max} characters long.
 acf-core.please_specify_at_most = Error: Please specify a value at most {max}.
 acf-core.not_allowed_on_console = Error: Console may not execute this command.
 acf-core.could_not_find_player = Error: Could not find a player by the name: <c2>{search}</c2>
-acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
 acf-core.no_command_matched_search = No command matched <c2>{search}</c2>.
 acf-core.help_page_information = - Showing page <c2>{page}</c2> of <c2>{totalpages}</c2> (<c3>{results}</c3> results).
 acf-core.help_no_results = Error: No more results.
+acf-core.help_header = <c3>=== </c3><c1>Showing help for </c1><c2>{command}</c2><c3> ===</c3>
+acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_header = <c3>=== </c3><c1>Showing detailed help for </c1><c2>{command}</c2><c3> ===</c3>
+acf-core.help_detailed_format = <c2>{name}</c2>: <c3>{description}</c3>
+acf-core.help_search_header = <c3>=== </c3><c1>Showing help for </c1><c2>{command}</c2> <c1>{search}</c1><c3> ===</c3>


### PR DESCRIPTION
Example:
code: https://github.com/VoxelGamesLib/VoxelGamesLibv2/blob/b02becffc6ee6c9e7685d88d2f264fee14cd37aa/VoxelGamesLib/src/main/java/com/voxelgameslib/voxelgameslib/command/commands/StatsCommands.java
normal help:
![https://i.imgur.com/eI3hnqP.png](https://i.imgur.com/eI3hnqP.png)
detailed param help:
![https://i.imgur.com/fgmYDtZ.png](https://i.imgur.com/fgmYDtZ.png)
search:
![https://i.imgur.com/S7OghFr.png](https://i.imgur.com/S7OghFr.png)

ToDo/Open questions:
- [ ] add proper formatters so that platforms can customize help formatting (think hover messages for minecraft platforms)
- [ ] what about params with no description? https://github.com/aikar/commands/commit/a26eb31a041c9657ab3c0a80e6ab91a3a3817fd5#diff-b3fa5ad87f01cbeccbb1ccaf1b05338cR51
- [ ] display detailed help in search?
- [ ] add message to help discover detailed help (as footer for normal help?)
- [x] remove sender field from param syntax (`/stats increment [sender] [user] <type> [amount]` needs to be `/stats increment <user> <type> [amount]`)
- [ ] nicer header for search
- [ ] makes this nicer https://github.com/aikar/commands/pull/106/commits/a4c67f66a2bbdb413a87d380d678183a46883073