### PR TITLE
Add Norwegian bokmål & nynorsk

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -76,7 +76,7 @@ public abstract class CommandManager <
 
     protected boolean usePerIssuerLocale = false;
     protected List<IssuerLocaleChangedCallback<I>> localeChangedCallbacks = Lists.newArrayList();
-    protected Set<Locale> supportedLanguages = Sets.newHashSet(Locales.ENGLISH, Locales.GERMAN, Locales.SPANISH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH);
+    protected Set<Locale> supportedLanguages = Sets.newHashSet(Locales.ENGLISH, Locales.GERMAN, Locales.SPANISH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH, Locales.NORWEGIAN_BOKMAAL, Locales.NORWEGIAN_NYNORSK);
     protected Map<MessageType, MF> formatters = new IdentityHashMap<>();
     protected MF defaultFormatter;
     protected int defaultHelpPerPage = 10;

--- a/core/src/main/java/co/aikar/commands/Locales.java
+++ b/core/src/main/java/co/aikar/commands/Locales.java
@@ -74,7 +74,8 @@ public class Locales {
     public static final Locale UKRANIAN = new Locale("uk");
     public static final Locale ARABIC = new Locale("ar");
     public static final Locale WELSH = new Locale("cy");
-
+    public static final Locale NORWEGIAN_BOKMAAL = new Locale("nb");
+    public static final Locale NORWEGIAN_NYNORSK = new Locale("nn");
 
     private final CommandManager manager;
     private final LocaleManager<CommandIssuer> localeManager;

--- a/languages/core/acf-core_nb.properties
+++ b/languages/core/acf-core_nb.properties
@@ -1,0 +1,46 @@
+# Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+acf-core.permission_denied = Beklager, du har ikke tilgang til denne kommandoen.
+acf-core.error_generic_logged = En feil har oppstått. Problemet har blitt logget. Beklager for all besvær dette har skapt.
+acf-core.unknown_command = Ukjent kommando, vennligst skriv <c2>/help</c2>.
+acf-core.invalid_syntax = Syntaks: <c2>{command}</c2> <c3>{syntax}</c3>
+acf-core.error_prefix = Feil: {message}
+acf-core.error_performing_command = Beklager, det oppsto en feil under kommandoen.
+acf-core.info_message = {message}
+acf-core.please_specify_one_of = Feil: Vennligst oppgi en av (<c2>{valid}</c2>).
+acf-core.must_be_a_number = Feil: {num} må være et tall.
+acf-core.must_be_min_length = Feil: Må være minst {min} tegn langt.
+acf-core.must_be_max_length = Feil: Må være maksimum {max} tegn langt.
+acf-core.please_specify_at_most = Feil: Vennligst oppgi en verdi på maksimum {max}.
+acf-core.please_specify_at_least = Feil: Vennligst oppgi en verdi på minst {min}.
+acf-core.not_allowed_on_console = Feil: Konsollen kan ikke utføre denne kommandoen.
+acf-core.could_not_find_player = Feil: Kunne ikke finne en spiller med navnet: <c2>{search}</c2>
+acf-core.no_command_matched_search = Ingen kommando matchet <c2>{search}</c2>.
+acf-core.help_page_information = - Viser side <c2>{page}</c2> av <c2>{totalpages}</c2> (<c3>{results}</c3> resultater).
+acf-core.help_no_results = Feil: Ingen flere resultater.
+acf-core.help_header = <c3>=== </c3><c1>Viser hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
+acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c1><c3> ===</c3>
+acf-core.help_detailed_command_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_parameter_format = <c2>{name}</c2>: <c3>{description}</c3>
+acf-core.help_search_header = <c3>=== </c3><c1>Søkeresultater for </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>

--- a/languages/core/acf-core_nb.properties
+++ b/languages/core/acf-core_nb.properties
@@ -40,7 +40,7 @@ acf-core.help_page_information = - Viser side <c2>{page}</c2> av <c2>{totalpages
 acf-core.help_no_results = Feil: Ingen flere resultater.
 acf-core.help_header = <c3>=== </c3><c1>Viser hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
-acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c1><c3> ===</c3>
+acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_detailed_command_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
 acf-core.help_detailed_parameter_format = <c2>{name}</c2>: <c3>{description}</c3>
 acf-core.help_search_header = <c3>=== </c3><c1>Søkeresultater for </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>

--- a/languages/core/acf-core_nn.properties
+++ b/languages/core/acf-core_nn.properties
@@ -1,0 +1,46 @@
+# Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+acf-core.permission_denied = Beklager, du har ikkje tilgang til denne kommandoen.
+acf-core.error_generic_logged = Ein feil oppstod. Problemet har varta logga. Beklager for all bry dette har skapa.
+acf-core.unknown_command = Ukjend kommando, skriv <c2>/help</c2> for meir informasjon.
+acf-core.invalid_syntax = Syntaks: <c2>{command}</c2> <c3>{syntax}</c3>
+acf-core.error_prefix = Feil: {message}
+acf-core.error_performing_command = Beklager, det oppstod ein feil under kommandoen sin køyretid.
+acf-core.info_message = {message}
+acf-core.please_specify_one_of = Feil: Gjev opp ein av (<c2>{valid}</c2>).
+acf-core.must_be_a_number = Feil: {num} må vere eit tal.
+acf-core.must_be_min_length = Feil: Må vere minst {min} teikn langt.
+acf-core.must_be_max_length = Feil: Må vere maksimum {max} teikn langt.
+acf-core.please_specify_at_most = Feil: Gjev opp ein verdi på maksimum {max}.
+acf-core.please_specify_at_least = Feil: Gjev opp ein verdi på minst {min}.
+acf-core.not_allowed_on_console = Feil: Konsollen kan ikkje føre ut denne kommandoen.
+acf-core.could_not_find_player = Feil: Kunne ikkje finne ein spelar med namnet: <c2>{search}</c2>
+acf-core.no_command_matched_search = Ingen kommando passa til <c2>{search}</c2>.
+acf-core.help_page_information = - Viser side <c2>{page}</c2> i <c2>{totalpages}</c2> (<c3>{results}</c3> utfall).
+acf-core.help_no_results = Feil: Ingen fleire utfall.
+acf-core.help_header = <c3>=== </c3><c1>Viser hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
+acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c1><c3> ===</c3>
+acf-core.help_detailed_command_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_parameter_format = <c2>{name}</c2>: <c3>{description}</c3>
+acf-core.help_search_header = <c3>=== </c3><c1>Søkjeutfall for </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>

--- a/languages/core/acf-core_nn.properties
+++ b/languages/core/acf-core_nn.properties
@@ -40,7 +40,7 @@ acf-core.help_page_information = - Viser side <c2>{page}</c2> i <c2>{totalpages}
 acf-core.help_no_results = Feil: Ingen fleire utfall.
 acf-core.help_header = <c3>=== </c3><c1>Viser hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
-acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c1><c3> ===</c3>
+acf-core.help_detailed_header = <c3>=== </c3><c1>Viser detaljert hjelp for </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_detailed_command_format = <c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
 acf-core.help_detailed_parameter_format = <c2>{name}</c2>: <c3>{description}</c3>
 acf-core.help_search_header = <c3>=== </c3><c1>Søkjeutfall for </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>

--- a/languages/minecraft/acf-minecraft_nb.properties
+++ b/languages/minecraft/acf-minecraft_nb.properties
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+acf-minecraft.invalid_world = Error: Verdenen eksisterer ikke.
+acf-minecraft.you_must_be_holding_item = Error: Du må holde et objekt i handa di.
+acf-minecraft.player_is_vanished_confirm = \
+    Advarsel: <c2>{vanished}</c2> er usynlig. Ikke ødelegg for dem!\n\
+    For å utføre handlingen, legg til <c2>:confirm</c2> til slutten av navnet deres.\n\
+    F.eks.: <c2>{vanished}:confirm</c2>
+acf-minecraft.username_too_short = Feil: Brukernavnet er for kort, det må være minst tre bokstaver langt.
+acf-minecraft.is_not_a_valid_name = Feil: <c2>{name}</c2> er ikke et gyldig brukernavn.
+acf-minecraft.multiple_players_match = Feil: Flere brukere matchet <c2>{search}</c2> <c3>({all})</c3>, vennligst vær mer spesifikk.
+acf-minecraft.no_player_found_server = Ingen spillere som matcher <c2>{search}</c2> er tilkoplet.
+acf-minecraft.no_player_found_offline = Ingen spillere som matcher <c2>{search}</c2> og har vært på serveren før kunne bli funnet.
+acf-minecraft.no_player_found = Ingen spillere som matcher <c2>{search}</c2> kunne bli funnet.
+acf-minecraft.location_please_specify_world = Feil: Vennligst oppgi verden. F.eks.: <c2>verden:x,y,z</c2>.
+acf-minecraft.location_please_specify_xyz = Feil: Vennligst oppgi x, y og z koordinater. F.eks.: <c2>verden:x,y,z</c2>.
+acf-minecraft.location_console_not_relative = Feil: Konsollen kan ikke bruke relative koordinater for posisjoner.

--- a/languages/minecraft/acf-minecraft_nn.properties
+++ b/languages/minecraft/acf-minecraft_nn.properties
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+acf-minecraft.invalid_world = Error: Verda finst ikke.
+acf-minecraft.you_must_be_holding_item = Error: Du må halde noko i handa di.
+acf-minecraft.player_is_vanished_confirm = \
+    Åtvaring: <c2>{vanished}</c2> er usynleg. Ikkje øydelegg for han!\n\
+    For å føre ut handlinga, legg til <c2>:confirm</c2> på slutten av namnet hans.\n\
+    Til døme: <c2>{vanished}:confirm</c2>
+acf-minecraft.username_too_short = Feil: Brukarnamnet er for kort, det må vere minst tre teikn langt.
+acf-minecraft.is_not_a_valid_name = Feil: <c2>{name}</c2> er ikkje eit gyldig brukarnamn.
+acf-minecraft.multiple_players_match = Feil: Fleire brukarar matcha <c2>{search}</c2> <c3>({all})</c3>, gjev opp eit meir spesifikt søk.
+acf-minecraft.no_player_found_server = Ingen spelarar som matchar <c2>{search}</c2> er kopla til.
+acf-minecraft.no_player_found_offline = Ingen spelarar som matchar <c2>{search}</c2> og har vore på sørvaren før kunne verte funnen.
+acf-minecraft.no_player_found = Ingen spelarar som matchar <c2>{search}</c2> kunne verte funnen i det heile.
+acf-minecraft.location_please_specify_world = Feil: Gjev opp ei verd. Til døme: <c2>verd:x,y,z</c2>.
+acf-minecraft.location_please_specify_xyz = Feil: Gjev opp x, y og z koordinatar. Til døme: <c2>verd:x,y,z</c2>.
+acf-minecraft.location_console_not_relative = Feil: Konsollen kan ikkje bruke relative koordinatar for posisjonar.


### PR DESCRIPTION
Adds the two written languages of Norway: Bokmål & Nynorsk. The codes are nb and nn respectively, according to ISO 639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes