### PR TITLE
Fix parsing, more safety, add named MessageChannels and format the code properly

### DIFF
--- a/jda/src/main/java/co/aikar/commands/JDACommandCompletions.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandCompletions.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public class JDACommandCompletions extends CommandCompletions<CommandCompletionContext<?>> {
     private boolean initialized;
+
     public JDACommandCompletions(CommandManager manager) {
         super(manager);
         this.initialized = true;

--- a/jda/src/main/java/co/aikar/commands/JDACommandConfig.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandConfig.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class JDACommandConfig implements CommandConfig {
-    protected @NotNull List<String> commandPrefixes = new CopyOnWriteArrayList<>(new String[] {"!"});
+    protected @NotNull List<String> commandPrefixes = new CopyOnWriteArrayList<>(new String[]{"!"});
 
     public JDACommandConfig() {
 

--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -1,11 +1,14 @@
 package co.aikar.commands;
 
+import co.aikar.commands.annotation.Author;
 import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.SelfUser;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageChannel;
+import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
@@ -21,10 +24,9 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
         this.jda = this.manager.getJDA();
         this.registerIssuerOnlyContext(JDACommandEvent.class, CommandExecutionContext::getIssuer);
         this.registerIssuerOnlyContext(MessageReceivedEvent.class, c -> c.getIssuer().getIssuer());
-        this.registerIssuerOnlyContext(Message.class, c -> {
-            MessageReceivedEvent event = c.getIssuer().getIssuer();
-            return event.getMessage();
-        });
+        this.registerIssuerOnlyContext(Message.class, c -> c.issuer.getIssuer().getMessage());
+        this.registerIssuerOnlyContext(ChannelType.class, c -> c.issuer.getIssuer().getChannelType());
+        this.registerIssuerOnlyContext(JDA.class, c -> jda);
         this.registerIssuerOnlyContext(Guild.class, c -> {
             MessageReceivedEvent event = c.getIssuer().getIssuer();
             if (event.isFromType(ChannelType.PRIVATE) && !c.hasAnnotation(Optional.class)) {
@@ -34,23 +36,39 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             }
         });
         this.registerIssuerOnlyContext(MessageChannel.class, c -> {
-            MessageReceivedEvent event = c.getIssuer().getIssuer();
-            return event.getChannel();
+            if (c.hasAnnotation(Author.class)) {
+                return c.issuer.getIssuer().getChannel();
+            }
+            String argument = c.popFirstArg();
+            MessageChannel channel = null;
+            if (argument.startsWith("<#")) {
+                channel = jda.getTextChannelById(argument.substring(2, argument.length() - 1));
+            } else {
+                List<TextChannel> channelList = c.issuer.getEvent().getGuild().getTextChannelsByName(argument.toLowerCase(), true);
+                if (channelList.size() > 1) {
+                    throw new InvalidCommandArgument("Too many channels were found with the given name. Try with the `#channelname` syntax.", false);
+                } else if (channelList.size() == 1) {
+                    channel = channelList.get(0);
+                }
+            }
+            if (channel == null) {
+                throw new InvalidCommandArgument("Couldn't find the channel with that name or ID.");
+            }
+            return channel;
         });
-        this.registerIssuerOnlyContext(ChannelType.class, c -> {
-            MessageReceivedEvent event = c.getIssuer().getIssuer();
-            return event.getChannelType();
-        });
-
-
-        this.registerIssuerOnlyContext(JDA.class, c -> jda);
         this.registerContext(User.class, c -> {
+            if (c.hasAnnotation(SelfUser.class)) {
+                return jda.getSelfUser();
+            }
             String arg = c.popFirstArg();
             User user = null;
-            if (arg.startsWith("@")) {
-                user = jda.getUserById(arg.substring(1));
+            if (arg.startsWith("<@")) {
+                user = jda.getUserById(arg.substring(2, arg.length() - 1));
             } else {
                 List<User> users = jda.getUsersByName(arg, true);
+                if (users.size() > 1) {
+                    throw new InvalidCommandArgument("Too many users were found with the given name. Try with the `@username#0000` syntax.", false);
+                }
                 if (!users.isEmpty()) {
                     user = users.get(0);
                 }
@@ -61,5 +79,4 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             return user;
         });
     }
-
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
@@ -59,6 +59,7 @@ public class JDACommandEvent implements CommandIssuer {
     public void sendMessage(Message message) {
         this.event.getChannel().sendMessage(message).queue();
     }
+
     public void sendMessage(MessageEmbed message) {
         this.event.getChannel().sendMessage(message).queue();
     }

--- a/jda/src/main/java/co/aikar/commands/JDACommandExecutionContext.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandExecutionContext.java
@@ -1,10 +1,9 @@
 package co.aikar.commands;
 
-import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Map;
 
-public class JDACommandExecutionContext extends CommandExecutionContext<JDACommandExecutionContext,JDACommandEvent> {
+public class JDACommandExecutionContext extends CommandExecutionContext<JDACommandExecutionContext, JDACommandEvent> {
     JDACommandExecutionContext(RegisteredCommand cmd, CommandParameter param, JDACommandEvent sender, List<String> args, int index, Map<String, Object> passedArgs) {
         super(cmd, param, sender, args, index, passedArgs);
     }

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -25,17 +25,15 @@ public class JDACommandManager extends CommandManager<
         > {
 
     private final JDA jda;
-
+    protected JDACommandCompletions completions;
+    protected JDACommandContexts contexts;
+    protected JDALocales locales;
+    protected Map<String, JDARootCommand> commands = Maps.newHashMap();
     private Logger logger;
     private CommandConfig defaultConfig;
     private CommandConfigProvider configProvider;
     private CommandPermissionResolver permissionResolver;
-    protected JDACommandCompletions completions;
-    protected JDACommandContexts contexts;
-    protected JDALocales locales;
     private long botOwner = 0L;
-
-    protected Map<String, JDARootCommand> commands = Maps.newHashMap();
 
     public JDACommandManager(JDA jda) {
         this(jda, null);
@@ -78,6 +76,10 @@ public class JDACommandManager extends CommandManager<
         });
     }
 
+    public static JDAOptions options() {
+        return new JDAOptions();
+    }
+
     void initializeBotOwner() {
         if (botOwner == 0L) {
             if (jda.getAccountType() == AccountType.BOT) {
@@ -92,11 +94,6 @@ public class JDACommandManager extends CommandManager<
         // Just in case initialization on ReadyEvent fails.
         initializeBotOwner();
         return botOwner;
-    }
-
-
-    public static JDAOptions options() {
-        return new JDAOptions();
     }
 
     public JDA getJDA() {
@@ -218,7 +215,7 @@ public class JDACommandManager extends CommandManager<
 
     void dispatchEvent(MessageReceivedEvent event) {
         Message message = event.getMessage();
-        String msg = message.getContentDisplay();
+        String msg = message.getContentRaw();
 
         CommandConfig config = getCommandConfig(event);
 

--- a/jda/src/main/java/co/aikar/commands/JDAOptions.java
+++ b/jda/src/main/java/co/aikar/commands/JDAOptions.java
@@ -8,7 +8,8 @@ public class JDAOptions {
     CommandConfigProvider configProvider = null;
     CommandPermissionResolver permissionResolver = null;
 
-    public JDAOptions() {}
+    public JDAOptions() {
+    }
 
     public JDAOptions defaultConfig(@NotNull CommandConfig defaultConfig) {
         this.defaultConfig = defaultConfig;

--- a/jda/src/main/java/co/aikar/commands/JDARootCommand.java
+++ b/jda/src/main/java/co/aikar/commands/JDARootCommand.java
@@ -8,12 +8,12 @@ import java.util.List;
 
 public class JDARootCommand implements RootCommand {
 
-    private JDACommandManager manager;
     private final String name;
+    boolean isRegistered = false;
+    private JDACommandManager manager;
     private BaseCommand defCommand;
     private SetMultimap<String, RegisteredCommand> subCommands = HashMultimap.create();
     private List<BaseCommand> children = new ArrayList<>();
-    boolean isRegistered = false;
 
     JDARootCommand(JDACommandManager manager, String name) {
         this.manager = manager;

--- a/jda/src/main/java/co/aikar/commands/annotation/Author.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/Author.java
@@ -1,0 +1,18 @@
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@link Author} annotation is to define whether the parameter should be the author object from the event or
+ * parsed from the user's input.
+ * <p>
+ * Using this on a User/Member will fetch the author, while if not, it'll parse the input.
+ * The same happens with channels, guilds, and so on.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Author {
+}

--- a/jda/src/main/java/co/aikar/commands/annotation/SelfUser.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/SelfUser.java
@@ -1,0 +1,11 @@
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SelfUser {
+}


### PR DESCRIPTION
I seem to have let https://github.com/aikar/commands/pull/112 slip into this, but I guess that's fine, as long as it's accepted. I can revert it on this branch if wanted.
This fixes https://github.com/aikar/commands/issues/113 and makes the contexts a bit more safe when it comes to e.g. banning users, as it no longer can pick one user of e.g. 10 who have the same name (possible, as if I name myself Aikar#0002, it'd be 100% accepted by Discord and all bots).

From now on, all bots will need to manually get the formatted message from the event if they wish to display or log it somewhere the displayname is wanted, as all bots get unformatted messages (i.e. `**<@0138917313> fat _italics_**` instead of `@nickname fat italics`).