### PR TITLE
Fix methodHandle error

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -151,7 +151,7 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
             if (passedArgs == null) return;
 
             if (methodHandle != null) {
-                methodHandle.invoke(passedArgs.values().toArray());
+                methodHandle.invokeWithArguments(passedArgs.values().toArray());
             } else {
                 // The offchance the method handle wasn't unreflected, we're going to use the slower, working reflection.
                 method.invoke(passedArgs.values().toArray());


### PR DESCRIPTION
Fix exception thrown by incorrect function

As of #112 using Any command will throw an exception. This hotfix was supplied by @Proximyst 

This was edited and created on mobile don’t judge at the small description.