### PR TITLE
Exception handler take care about logging

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -177,8 +177,8 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
             try {
                 if (!this.manager.handleUncaughtException(scope, this, sender, args, e)) {
                     sender.sendMessage(MessageType.ERROR, MessageKeys.ERROR_PERFORMING_COMMAND);
+                    this.manager.log(LogLevel.ERROR, "Exception in command: " + command + " " + ACFUtil.join(args), e);
                 }
-                this.manager.log(LogLevel.ERROR, "Exception in command: " + command + " " + ACFUtil.join(args), e);
             } catch (Exception e2) {
                 this.manager.log(LogLevel.ERROR, "Exception in handleException for command: " + command + " " + ACFUtil.join(args), e);
                 this.manager.log(LogLevel.ERROR, "Exception triggered by exception handler:", e2);


### PR DESCRIPTION
Why if we have exception handler, ACF still loging all exceptions?
For example, I need to throw IllegalArgumentException with text "Value should be a number, can start with + or -". In this case I use exception handler as point where I can mange all error messages and it's cool. I not need to log all exceptions.

And I can just write following code and it will work fine:
```java
manager.setDefaultExceptionHandler((command, registeredCommand, sender, args, t) -> {
        if (t instanceof IllegalArgumentException || t instanceof UnsupportedOperationException) {
            sender.sendError(MessageKeys.ERROR_PREFIX, "{message}", t.getMessage());
            return false;
        }

        return false;
    });
```