### PR TITLE
Support old user names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# eclipse project file
+.settings/
+.classpath
+.project
+

--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
@@ -256,10 +256,7 @@ public class ACFBukkitUtil {
             return null;
         }
         String name = ACFUtil.replace(search, ":confirm", "");
-        if (name.length() < 3) {
-            issuer.sendError(MinecraftMessageKeys.USERNAME_TOO_SHORT);
-            return null;
-        }
+
         if (!isValidName(name)) {
             issuer.sendError(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
             return null;

--- a/core/src/main/java/co/aikar/commands/ACFPatterns.java
+++ b/core/src/main/java/co/aikar/commands/ACFPatterns.java
@@ -44,7 +44,7 @@ final class ACFPatterns {
     public static final Pattern PIPE = Pattern.compile("\\|");
     public static final Pattern NON_ALPHA_NUMERIC = Pattern.compile("[^a-zA-Z0-9]");
     public static final Pattern INTEGER = Pattern.compile("^[0-9]+$");
-    public static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]{2,16}$");
+    public static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_$]{1,16}$");
     public static final Pattern NON_PRINTABLE_CHARACTERS = Pattern.compile("[^\\x20-\\x7F]");
     public static final Pattern EQUALS = Pattern.compile("=");
     public static final Pattern FORMATTER = Pattern.compile("<c(?<color>\\d+)>(?<msg>.*?)</c\\1>", Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
Recently a player with a two letter account joined on my server and I noticed that the context resolver for the player interface does not work. This PR also fixes crazy names like these:
https://de.namemc.com/profile/%24.1
https://de.namemc.com/profile/u.1

