### PR TITLE
Implement CommandPermissionResolver

### DIFF
--- a/jda/src/main/java/co/aikar/commands/CommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/CommandPermissionResolver.java
@@ -2,5 +2,5 @@ package co.aikar.commands;
 
 
 public interface CommandPermissionResolver {
-    boolean hasPermission(JDACommandEvent event, String permission);
+    boolean hasPermission(JDACommandManager manager, JDACommandEvent event, String permission);
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandEvent.java
@@ -48,7 +48,7 @@ public class JDACommandEvent implements CommandIssuer {
     @Override
     public boolean hasPermission(String permission) {
         CommandPermissionResolver permissionResolver = this.manager.getPermissionResolver();
-        return permissionResolver == null || permissionResolver.hasPermission(this, permission);
+        return permissionResolver == null || permissionResolver.hasPermission(manager, this, permission);
     }
 
     @Override

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -42,6 +42,7 @@ public class JDACommandManager extends CommandManager<
     public JDACommandManager(JDA jda, JDAOptions options) {
         if (options == null) {
             options = new JDAOptions();
+            options.permissionResolver = new JDACommandPermissionResolver(this); // I do not like this here. Suggestions please.
         }
         this.jda = jda;
         this.permissionResolver = options.permissionResolver;

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -42,7 +42,6 @@ public class JDACommandManager extends CommandManager<
     public JDACommandManager(JDA jda, JDAOptions options) {
         if (options == null) {
             options = new JDAOptions();
-            options.permissionResolver = new JDACommandPermissionResolver(this); // I do not like this here. Suggestions please.
         }
         this.jda = jda;
         this.permissionResolver = options.permissionResolver;

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -90,7 +90,7 @@ public class JDACommandManager extends CommandManager<
         }
     }
 
-    private long getBotOwnerId() {
+    public long getBotOwnerId() {
         // Just in case initialization on ReadyEvent fails.
         initializeBotOwner();
         return botOwner;

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -1,0 +1,45 @@
+package co.aikar.commands;
+
+
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JDACommandPermissionResolver implements CommandPermissionResolver {
+    private Map<String, Integer> discordPermissionOffsets;
+
+    public JDACommandPermissionResolver() {
+        discordPermissionOffsets = new HashMap<>();
+        for (Permission permission : Permission.values()) {
+            discordPermissionOffsets.put(permission.name().toLowerCase().replaceAll("_", "-"), permission.getOffset());
+        }
+    }
+
+    @Override
+    public boolean hasPermission(JDACommandEvent event, String permission) {
+        Member guildMember = event.getIssuer().getMember();
+        if (guildMember == null) {
+            return false;
+        }
+
+        // TODO: regex
+        if (permission.startsWith("role.")) {
+            String perm = permission.split("role.")[1];
+            List<Role> roles = event.getIssuer().getJDA().getRolesByName(perm, true);
+            if (roles.size() == 1) {
+                return guildMember.getRoles().contains(roles.get(0));
+            }
+
+            return false;
+        }
+
+        // TODO: We need to check if the event is for a specific channel
+        int permissionOffset = discordPermissionOffsets.get(permission);
+        Permission discordPermission = Permission.getFromOffset(permissionOffset);
+        return guildMember.hasPermission(discordPermission);
+    }
+}

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -1,7 +1,6 @@
 package co.aikar.commands;
 
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.Member;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -1,6 +1,5 @@
 package co.aikar.commands;
 
-
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Member;
 
@@ -8,9 +7,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class JDACommandPermissionResolver implements CommandPermissionResolver {
+    private JDACommandManager jdaCommandManager;
     private Map<String, Integer> discordPermissionOffsets;
 
-    public JDACommandPermissionResolver() {
+    public JDACommandPermissionResolver(JDACommandManager jdaCommandManager) {
+        this.jdaCommandManager = jdaCommandManager;
         discordPermissionOffsets = new HashMap<>();
         for (Permission permission : Permission.values()) {
             discordPermissionOffsets.put(permission.name().toLowerCase().replaceAll("_", "-"), permission.getOffset());
@@ -19,12 +20,8 @@ public class JDACommandPermissionResolver implements CommandPermissionResolver {
 
     @Override
     public boolean hasPermission(JDACommandEvent event, String permission) {
-        Member guildMember = event.getIssuer().getMember();
-        if (guildMember == null) {
-            return false;
-        }
-
-        if (guildMember.isOwner()) {
+        // Explicitly return true if the issuer is the bot's owner. They are always allowed.
+        if (jdaCommandManager.getBotOwnerId() == event.getIssuer().getAuthor().getIdLong()) {
             return true;
         }
 
@@ -33,7 +30,7 @@ public class JDACommandPermissionResolver implements CommandPermissionResolver {
             return false;
         }
 
-        return guildMember.hasPermission(
+        return event.getIssuer().getMember().hasPermission(
                 Permission.getFromOffset(permissionOffset)
         );
     }

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -24,6 +24,10 @@ public class JDACommandPermissionResolver implements CommandPermissionResolver {
             return false;
         }
 
+        if (guildMember.isOwner()) {
+            return true;
+        }
+
         Integer permissionOffset = discordPermissionOffsets.get(permission);
         if (permissionOffset == null) {
             return false;

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -3,10 +3,8 @@ package co.aikar.commands;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Member;
-import net.dv8tion.jda.core.entities.Role;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class JDACommandPermissionResolver implements CommandPermissionResolver {
@@ -26,20 +24,13 @@ public class JDACommandPermissionResolver implements CommandPermissionResolver {
             return false;
         }
 
-        // TODO: regex
-        if (permission.startsWith("role.")) {
-            String perm = permission.split("role.")[1];
-            List<Role> roles = event.getIssuer().getJDA().getRolesByName(perm, true);
-            if (roles.size() == 1) {
-                return guildMember.getRoles().contains(roles.get(0));
-            }
-
+        Integer permissionOffset = discordPermissionOffsets.get(permission);
+        if (permissionOffset == null) {
             return false;
         }
 
-        // TODO: We need to check if the event is for a specific channel
-        int permissionOffset = discordPermissionOffsets.get(permission);
-        Permission discordPermission = Permission.getFromOffset(permissionOffset);
-        return guildMember.hasPermission(discordPermission);
+        return guildMember.hasPermission(
+                Permission.getFromOffset(permissionOffset)
+        );
     }
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandPermissionResolver.java
@@ -6,11 +6,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class JDACommandPermissionResolver implements CommandPermissionResolver {
-    private JDACommandManager jdaCommandManager;
     private Map<String, Integer> discordPermissionOffsets;
 
-    public JDACommandPermissionResolver(JDACommandManager jdaCommandManager) {
-        this.jdaCommandManager = jdaCommandManager;
+    public JDACommandPermissionResolver() {
         discordPermissionOffsets = new HashMap<>();
         for (Permission permission : Permission.values()) {
             discordPermissionOffsets.put(permission.name().toLowerCase().replaceAll("_", "-"), permission.getOffset());
@@ -18,9 +16,9 @@ public class JDACommandPermissionResolver implements CommandPermissionResolver {
     }
 
     @Override
-    public boolean hasPermission(JDACommandEvent event, String permission) {
+    public boolean hasPermission(JDACommandManager manager, JDACommandEvent event, String permission) {
         // Explicitly return true if the issuer is the bot's owner. They are always allowed.
-        if (jdaCommandManager.getBotOwnerId() == event.getIssuer().getAuthor().getIdLong()) {
+        if (manager.getBotOwnerId() == event.getIssuer().getAuthor().getIdLong()) {
             return true;
         }
 

--- a/jda/src/main/java/co/aikar/commands/JDAOptions.java
+++ b/jda/src/main/java/co/aikar/commands/JDAOptions.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 public class JDAOptions {
     CommandConfig defaultConfig = new JDACommandConfig();
     CommandConfigProvider configProvider = null;
-    CommandPermissionResolver permissionResolver = new JDACommandPermissionResolver();
+    CommandPermissionResolver permissionResolver = null;
 
     public JDAOptions() {
     }

--- a/jda/src/main/java/co/aikar/commands/JDAOptions.java
+++ b/jda/src/main/java/co/aikar/commands/JDAOptions.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 public class JDAOptions {
     CommandConfig defaultConfig = new JDACommandConfig();
     CommandConfigProvider configProvider = null;
-    CommandPermissionResolver permissionResolver = null;
+    CommandPermissionResolver permissionResolver = new JDACommandPermissionResolver();
 
     public JDAOptions() {
     }


### PR DESCRIPTION
This pull request is an initial attempt at implementing permission for commands for the JDA module.

It includes one added file, **JDACommandPermissionResolver** which implements CommandPermissionResolver.

I created a map to store the Discord permission offsets stored mapped by their kebab-cased name (i.e. "ADMINISTRATOR" becomes "administrator", "MANAGE_SERVER" becomes "manage-server".

The implementation of `hasPermission(JDACommandEvent, String)` is fairly simple:

- Get the issuer's Member object
- Check if it's null; if so, return false.
- Get the permission offset from the aforementioned map
- Check if it's null; if so, return false.
- Return whether or not the member has the permission.

---------------------------------------

This PR allows new commands to use the `@CommandPermission` annotation like so:
```java
@CommandAlias("test|t")
public class Command extends BaseCommand {
  @Subcommand("admin|a")
  @CommandPermission("manage-server")
  public void adminCommand(MessageReceivedEvent event) {
    //...
  }
}
```