### PR TITLE
Reimplement JDAMessageFormatter for Discord

### DIFF
--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -48,6 +48,7 @@ public class JDACommandManager extends CommandManager<
         jda.addEventListener(new JDAListener(this));
         this.defaultConfig = options.defaultConfig == null ? new JDACommandConfig() : options.defaultConfig;
         this.configProvider = options.configProvider;
+        this.defaultFormatter = new JDAMessageFormatter();
         this.completions = new JDACommandCompletions(this);
         this.logger = Logger.getLogger(this.getClass().getSimpleName());
 

--- a/jda/src/main/java/co/aikar/commands/JDAMessageFormatter.java
+++ b/jda/src/main/java/co/aikar/commands/JDAMessageFormatter.java
@@ -1,6 +1,12 @@
 package co.aikar.commands;
 
 public class JDAMessageFormatter extends MessageFormatter<String> {
+    public JDAMessageFormatter() {
+        // JDA does not support coloring messages outside of embed fields.
+        // We pass three empty strings so as to remove color coded messages from appearing.
+        super("", "", "");
+    }
+
     @Override
     String format(String color, String message) {
         return message;


### PR DESCRIPTION
Because Discord does not support coloring messages outside of embeddable fields, it is safe to use a simple message formatter than just returns the message itself.

As I was testing my previous PR, I noticed messages coming through with coloring symbols (e.g. `<c1></c1>`), and each only went up to `c3` maximum. Finally, I figured out these were colors that needed to be handled in each case.

To remove colored messages from Discord, the message formatter is passed three empty strings for each of `c1`, `c2`, and `c3` respectively.

Finally, the default formatter is set inside of `JDACommandManager` but can always be overridden by the user.