### PR TITLE
Repair context types, add Role context, add CrossGuild annotation

### DIFF
--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -43,7 +43,7 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
                 return c.issuer.getIssuer().getChannel();
             }
             boolean isCrossGuild = c.hasAnnotation(CrossGuild.class);
-            String argument = c.popFirstArg();
+            String argument = c.popFirstArg(); // we pop because we are only issuer aware if we are annotated
             MessageChannel channel = null;
             if (argument.startsWith("<#")) {
                 String id = argument.substring(2, argument.length() - 1);
@@ -66,7 +66,7 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             if (c.hasAnnotation(SelfUser.class)) {
                 return jda.getSelfUser();
             }
-            String arg = c.popFirstArg();
+            String arg = c.popFirstArg(); // we pop because we are only issuer aware if we are annotated
             User user = null;
             if (arg.startsWith("<@")) {
                 user = jda.getUserById(arg.substring(2, arg.length() - 1));
@@ -86,7 +86,7 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
         });
         this.registerContext(Role.class, c -> {
             boolean isCrossGuild = c.hasAnnotation(CrossGuild.class);
-            String arg = c.popFirstArg();
+            String arg = c.popFirstArg(); // not issuer aware
             Role role = null;
             if (arg.startsWith("<@&")) {
                 String id = arg.substring(3, arg.length() - 1);

--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -86,7 +86,7 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
         });
         this.registerContext(Role.class, c -> {
             boolean isCrossGuild = c.hasAnnotation(CrossGuild.class);
-            String arg = c.popFirstArg(); // not issuer aware
+            String arg = c.popFirstArg();
             Role role = null;
             if (arg.startsWith("<@&")) {
                 String id = arg.substring(3, arg.length() - 1);

--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -5,15 +5,18 @@ import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.SelfUser;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.ChannelType;
+import net.dv8tion.jda.core.entities.Game;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageChannel;
+import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
 import java.util.List;
 
+// TODO: Message Keys !!!
 public class JDACommandContexts extends CommandContexts<JDACommandExecutionContext> {
     private final JDACommandManager manager;
     private final JDA jda;
@@ -30,12 +33,12 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
         this.registerIssuerOnlyContext(Guild.class, c -> {
             MessageReceivedEvent event = c.getIssuer().getIssuer();
             if (event.isFromType(ChannelType.PRIVATE) && !c.hasAnnotation(Optional.class)) {
-                throw new InvalidCommandArgument("This command can only be executed in a Guild.", false); // TODO: Message Keys
+                throw new InvalidCommandArgument("This command can only be executed in a Guild.", false);
             } else {
                 return event.getGuild();
             }
         });
-        this.registerIssuerOnlyContext(MessageChannel.class, c -> {
+        this.registerIssuerAwareContext(MessageChannel.class, c -> {
             if (c.hasAnnotation(Author.class)) {
                 return c.issuer.getIssuer().getChannel();
             }
@@ -44,7 +47,7 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             if (argument.startsWith("<#")) {
                 channel = jda.getTextChannelById(argument.substring(2, argument.length() - 1));
             } else {
-                List<TextChannel> channelList = c.issuer.getEvent().getGuild().getTextChannelsByName(argument.toLowerCase(), true);
+                List<TextChannel> channelList = c.issuer.getEvent().getGuild().getTextChannelsByName(argument, true);
                 if (channelList.size() > 1) {
                     throw new InvalidCommandArgument("Too many channels were found with the given name. Try with the `#channelname` syntax.", false);
                 } else if (channelList.size() == 1) {
@@ -52,11 +55,11 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
                 }
             }
             if (channel == null) {
-                throw new InvalidCommandArgument("Couldn't find the channel with that name or ID.");
+                throw new InvalidCommandArgument("Couldn't find a channel with that name or ID.");
             }
             return channel;
         });
-        this.registerContext(User.class, c -> {
+        this.registerIssuerAwareContext(User.class, c -> {
             if (c.hasAnnotation(SelfUser.class)) {
                 return jda.getSelfUser();
             }
@@ -74,9 +77,28 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
                 }
             }
             if (user == null) {
-                throw new InvalidCommandArgument("Could not find a user with that name or ID"); // TODO: Message keys
+                throw new InvalidCommandArgument("Could not find a user with that name or ID.");
             }
             return user;
+        });
+        this.registerContext(Role.class, c -> {
+            String arg = c.popFirstArg();
+            Role role = null;
+            if (arg.startsWith("<@&")) {
+                role = jda.getRoleById(Long.parseLong(arg.substring(3, arg.length() - 1)));
+            } else {
+                List<Role> roles = jda.getRolesByName(arg, true);
+                if (roles.size() > 1) {
+                    throw new InvalidCommandArgument("Too many roles were found with the given name. Try with the `@role` syntax.", false);
+                }
+                if (!roles.isEmpty()) {
+                    role = roles.get(0);
+                }
+            }
+            if (role == null) {
+                throw new InvalidCommandArgument("Could not find a role with that name or ID.");
+            }
+            return role;
         });
     }
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -6,7 +6,6 @@ import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.SelfUser;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.ChannelType;
-import net.dv8tion.jda.core.entities.Game;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageChannel;

--- a/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandContexts.java
@@ -1,6 +1,7 @@
 package co.aikar.commands;
 
 import co.aikar.commands.annotation.Author;
+import co.aikar.commands.annotation.CrossGuild;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.SelfUser;
 import net.dv8tion.jda.core.JDA;
@@ -42,12 +43,15 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             if (c.hasAnnotation(Author.class)) {
                 return c.issuer.getIssuer().getChannel();
             }
+            boolean isCrossGuild = c.hasAnnotation(CrossGuild.class);
             String argument = c.popFirstArg();
             MessageChannel channel = null;
             if (argument.startsWith("<#")) {
-                channel = jda.getTextChannelById(argument.substring(2, argument.length() - 1));
+                String id = argument.substring(2, argument.length() - 1);
+                channel = isCrossGuild ? jda.getTextChannelById(id) : c.issuer.getIssuer().getGuild().getTextChannelById(id);
             } else {
-                List<TextChannel> channelList = c.issuer.getEvent().getGuild().getTextChannelsByName(argument, true);
+                List<TextChannel> channelList = isCrossGuild ? jda.getTextChannelsByName(argument, true) :
+                        c.issuer.getEvent().getGuild().getTextChannelsByName(argument, true);
                 if (channelList.size() > 1) {
                     throw new InvalidCommandArgument("Too many channels were found with the given name. Try with the `#channelname` syntax.", false);
                 } else if (channelList.size() == 1) {
@@ -82,12 +86,15 @@ public class JDACommandContexts extends CommandContexts<JDACommandExecutionConte
             return user;
         });
         this.registerContext(Role.class, c -> {
+            boolean isCrossGuild = c.hasAnnotation(CrossGuild.class);
             String arg = c.popFirstArg();
             Role role = null;
             if (arg.startsWith("<@&")) {
-                role = jda.getRoleById(Long.parseLong(arg.substring(3, arg.length() - 1)));
+                String id = arg.substring(3, arg.length() - 1);
+                role = isCrossGuild ? jda.getRoleById(id) : c.issuer.getIssuer().getGuild().getRoleById(id);
             } else {
-                List<Role> roles = jda.getRolesByName(arg, true);
+                List<Role> roles = isCrossGuild ? jda.getRolesByName(arg, true)
+                        : c.issuer.getIssuer().getGuild().getRolesByName(arg, true);
                 if (roles.size() > 1) {
                     throw new InvalidCommandArgument("Too many roles were found with the given name. Try with the `@role` syntax.", false);
                 }

--- a/jda/src/main/java/co/aikar/commands/annotation/Author.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/Author.java
@@ -9,8 +9,8 @@ import java.lang.annotation.Target;
  * The {@link Author} annotation is to define whether the parameter should be the author object from the event or
  * parsed from the user's input.
  * <p>
- * Using this on a User/Member will fetch the author, while if not, it'll parse the input.
- * The same happens with channels, guilds, and so on.
+ *      Using this on a User/Member will fetch the author and otherwise it'll parse the input.
+ * </p>
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/jda/src/main/java/co/aikar/commands/annotation/CrossGuild.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/CrossGuild.java
@@ -5,6 +5,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * The {@link CrossGuild} annotation is to define whether the parameter should be guild-specific or global.
+ * <p>
+ *     If a supported parameter is marked with the CrossGuild annotation, the parameter will be filled from
+ *     a global perspective (i.e., all of the guilds the bot is connected to). Otherwise, the parameter will
+ *     be filled from command input.
+ * </p>
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CrossGuild {

--- a/jda/src/main/java/co/aikar/commands/annotation/CrossGuild.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/CrossGuild.java
@@ -1,0 +1,11 @@
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CrossGuild {
+}

--- a/jda/src/main/java/co/aikar/commands/annotation/SelfUser.java
+++ b/jda/src/main/java/co/aikar/commands/annotation/SelfUser.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * The {@link SelfUser} annotation is to define whether the parameter should be represented by JDA's user object
+ * or if it should be parsed from command input.
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SelfUser {


### PR DESCRIPTION
In a previous PR, some contexts were not changed from **IssuerOnly** to **IssuerAware**. This has been patched.

I've added a context to resolve a Role. It makes use of the next item I added.

The CrossGuild annotation is used to signify whether or not the context is to be interpreted from a guild perspective or a bot perspective (i.e. all guilds). This annotation could probably be better named.