### PR TITLE
Added command flags

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -15,7 +15,6 @@
         <module name="acf-jda" />
         <module name="acf-paper" />
         <module name="acf-sponge" />
-        <module name="commands" />
         <module name="example-plugin" />
       </profile>
     </annotationProcessing>

--- a/.idea/hotswap_agent.xml
+++ b/.idea/hotswap_agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="HotSwapAgentPluginSettingsProvider">
+    <option name="agentPath" value="C:\Users\ZENEGIX\.IntelliJIdea2018.1\config\plugins\hotswap-agent-intellij-plugin\lib\agent\hotswap-agent-1.3.0.jar" />
+  </component>
+</project>

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandExecutionContext.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandExecutionContext.java
@@ -32,8 +32,8 @@ import java.util.Map;
 
 public class BukkitCommandExecutionContext extends CommandExecutionContext<BukkitCommandExecutionContext, BukkitCommandIssuer> {
     BukkitCommandExecutionContext(RegisteredCommand cmd, CommandParameter param, BukkitCommandIssuer sender, List<String> args,
-                                  int index, Map<String, Object> passedArgs) {
-        super(cmd, param, sender, args, index, passedArgs);
+                                  Map<String, String> commandFlags, int index, Map<String, Object> passedArgs) {
+        super(cmd, param, sender, args, commandFlags, index, passedArgs);
     }
 
     public CommandSender getSender() {

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -324,8 +324,11 @@ public class BukkitCommandManager extends CommandManager<
     }
 
     @Override
-    public BukkitCommandExecutionContext createCommandContext(RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args, int i, Map<String, Object> passedArgs) {
-        return new BukkitCommandExecutionContext(command, parameter, (BukkitCommandIssuer) sender, args, i, passedArgs);
+    public BukkitCommandExecutionContext createCommandContext
+            (RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args,
+             Map<String, String> commandFlags, int i, Map<String, Object> passedArgs) {
+        return new BukkitCommandExecutionContext(command, parameter, (BukkitCommandIssuer) sender, args,
+                commandFlags, i, passedArgs);
     }
 
     @Override

--- a/bukkit/src/main/java/co/aikar/commands/flags/PlayerCommandFlag.java
+++ b/bukkit/src/main/java/co/aikar/commands/flags/PlayerCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,39 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import org.bukkit.entity.Player;
 
-    static final String LOG_PREFIX = "[ACF] ";
+public class PlayerCommandFlag extends AbstractCommandFlag<PlayerCommandFlag.PlayerCommandFlagType, Player> {
+
+    public static final PlayerCommandFlagType TYPE = new PlayerCommandFlagType();
+
+    public PlayerCommandFlag() {
+        super();
+    }
+
+    public PlayerCommandFlag(Player value) {
+        super(value);
+    }
+
+    @Override
+    public PlayerCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class PlayerCommandFlagType implements CommandFlagType<PlayerCommandFlagType, Player> {
+
+        @Override
+        public CommandFlag<PlayerCommandFlagType, Player> create(Player value) {
+            return new PlayerCommandFlag(value);
+        }
+
+        @Override
+        public Class<Player> getValueType() {
+            return Player.class;
+        }
+
+    }
+
 }

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandExecutionContext.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandExecutionContext.java
@@ -32,8 +32,9 @@ import java.util.Map;
 
 public class BungeeCommandExecutionContext extends CommandExecutionContext<BungeeCommandExecutionContext, BungeeCommandIssuer> {
 
-    BungeeCommandExecutionContext(RegisteredCommand cmd, CommandParameter param, BungeeCommandIssuer sender, List<String> args, int index, Map<String, Object> passedArgs) {
-        super(cmd, param, sender, args, index, passedArgs);
+    BungeeCommandExecutionContext(RegisteredCommand cmd, CommandParameter param, BungeeCommandIssuer sender, List<String> args,
+                                  Map<String, String> commandFlags, int index, Map<String, Object> passedArgs) {
+        super(cmd, param, sender, args, commandFlags, index, passedArgs);
     }
 
     public CommandSender getSender() {

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -184,8 +184,11 @@ public class BungeeCommandManager extends CommandManager<
     }
 
     @Override
-    public BungeeCommandExecutionContext createCommandContext(RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args, int i, Map<String, Object> passedArgs) {
-        return new BungeeCommandExecutionContext(command, parameter, (BungeeCommandIssuer) sender, args, i, passedArgs);
+    public BungeeCommandExecutionContext createCommandContext
+            (RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args,
+             Map<String, String> commandFlags, int i, Map<String, Object> passedArgs) {
+        return new BungeeCommandExecutionContext(command, parameter, (BungeeCommandIssuer) sender, args,
+                commandFlags, i, passedArgs);
     }
 
     @Override

--- a/bungee/src/main/java/co/aikar/commands/flags/ProxiedPlayerCommandFlag.java
+++ b/bungee/src/main/java/co/aikar/commands/flags/ProxiedPlayerCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,39 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-    static final String LOG_PREFIX = "[ACF] ";
+public class ProxiedPlayerCommandFlag extends AbstractCommandFlag<ProxiedPlayerCommandFlag.ProxiedPlayerCommandFlagType, ProxiedPlayer> {
+
+    public static final ProxiedPlayerCommandFlagType TYPE = new ProxiedPlayerCommandFlagType();
+
+    public ProxiedPlayerCommandFlag() {
+        super();
+    }
+
+    public ProxiedPlayerCommandFlag(ProxiedPlayer value) {
+        super(value);
+    }
+
+    @Override
+    public ProxiedPlayerCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class ProxiedPlayerCommandFlagType implements CommandFlagType<ProxiedPlayerCommandFlagType, ProxiedPlayer> {
+
+        @Override
+        public CommandFlag<ProxiedPlayerCommandFlagType, ProxiedPlayer> create(ProxiedPlayer value) {
+            return new ProxiedPlayerCommandFlag(value);
+        }
+
+        @Override
+        public Class<ProxiedPlayer> getValueType() {
+            return ProxiedPlayer.class;
+        }
+
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/ACFUtil.java
+++ b/core/src/main/java/co/aikar/commands/ACFUtil.java
@@ -24,7 +24,10 @@
 package co.aikar.commands;
 
 
+import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
+import co.aikar.commands.flags.CommandFlagType;
+import co.aikar.commands.flags.StateCommandFlag;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
@@ -33,7 +36,9 @@ import java.text.Normalizer.Form;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/core/src/main/java/co/aikar/commands/CommandExecutionContext.java
+++ b/core/src/main/java/co/aikar/commands/CommandExecutionContext.java
@@ -23,8 +23,6 @@
 
 package co.aikar.commands;
 
-import co.aikar.commands.contexts.ContextResolver;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
 import java.util.List;
@@ -39,10 +37,11 @@ public class CommandExecutionContext <CEC extends CommandExecutionContext, I ext
     private final int index;
     private final Map<String, Object> passedArgs;
     private final Map<String, String> flags;
+    private final Map<String, String> commandFlags;
     private final CommandManager manager;
 
     CommandExecutionContext(RegisteredCommand cmd, CommandParameter param, I sender, List<String> args,
-                            int index, Map<String, Object> passedArgs) {
+                            Map<String, String> commandFlags, int index, Map<String, Object> passedArgs) {
         this.cmd = cmd;
         this.manager = cmd.scope.manager;
         this.param = param;
@@ -51,6 +50,7 @@ public class CommandExecutionContext <CEC extends CommandExecutionContext, I ext
         this.index = index;
         this.passedArgs = passedArgs;
         this.flags = param.getFlags();
+        this.commandFlags = commandFlags;
 
     }
 
@@ -223,6 +223,10 @@ public class CommandExecutionContext <CEC extends CommandExecutionContext, I ext
 
     public Map<String, String> getFlags() {
         return this.flags;
+    }
+
+    public Map<String, String> getCommandFlags() {
+        return this.commandFlags;
     }
 
     public String joinArgs() {

--- a/core/src/main/java/co/aikar/commands/CommandOperationContext.java
+++ b/core/src/main/java/co/aikar/commands/CommandOperationContext.java
@@ -24,6 +24,10 @@
 package co.aikar.commands;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Holds information about the currently executing command on this thread
@@ -35,6 +39,7 @@ public class CommandOperationContext <I extends CommandIssuer> {
     private final BaseCommand command;
     private final String commandLabel;
     private final String[] args;
+    private final Map<String, String> commandFlags;
     private final boolean isAsync;
     private RegisteredCommand registeredCommand;
 
@@ -43,8 +48,12 @@ public class CommandOperationContext <I extends CommandIssuer> {
         this.issuer = issuer;
         this.command = command;
         this.commandLabel = commandLabel;
-        this.args = args;
         this.isAsync = isAsync;
+
+        List<String> argList = new ArrayList<>(Arrays.asList(args));
+        //noinspection unchecked
+        this.commandFlags = manager.separateFlags(argList);
+        this.args = argList.toArray(new String[0]);
     }
 
     public CommandManager getCommandManager() {
@@ -61,6 +70,10 @@ public class CommandOperationContext <I extends CommandIssuer> {
 
     public String getCommandLabel() {
         return commandLabel;
+    }
+
+    public Map<String, String> getCommandFlags() {
+        return this.commandFlags;
     }
 
     public String[] getArgs() {

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -32,6 +32,10 @@ import co.aikar.commands.annotation.HelpSearchTags;
 import co.aikar.commands.annotation.Private;
 import co.aikar.commands.annotation.Syntax;
 import co.aikar.commands.contexts.ContextResolver;
+import co.aikar.commands.flags.CommandFlag;
+import co.aikar.commands.flags.CommandFlagResolver;
+import co.aikar.commands.flags.CommandFlagType;
+import co.aikar.commands.resolver.Resolver;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -197,7 +201,7 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
     @Nullable
     Map<String, Object> resolveContexts(CommandIssuer sender, List<String> args, int argLimit) throws InvalidCommandArgument {
         args = Lists.newArrayList(args);
-        String[] origArgs = args.toArray(new String[args.size()]);
+        String[] origArgs = args.toArray(new String[0]);
         Map<String, Object> passedArgs = Maps.newLinkedHashMap();
         int remainingRequired = requiredResolvers;
         CommandOperationContext opContext = CommandManager.getCurrentCommandOperationContext();
@@ -211,18 +215,20 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
             final String parameterName = parameter.getName();
             final Class<?> type = parameter.getType();
             //noinspection unchecked
-            final ContextResolver<?, CEC> resolver = parameter.getResolver();
+            final Resolver<?, CEC> resolver = parameter.getResolver();
             //noinspection unchecked
-            CEC context = (CEC) this.manager.createCommandContext(this, parameter, sender, args, i, passedArgs);
+            CEC context = (CEC) this.manager.createCommandContext(this, parameter, sender, args,
+                    opContext.getCommandFlags(), i, passedArgs);
             boolean requiresInput = parameter.requiresInput();
-            if (requiresInput && remainingRequired > 0) {
+
+            if (requiresInput && remainingRequired > 0)
                 remainingRequired--;
-            }
-            if (args.isEmpty() && !(isLast && type == String[].class)) {
+
+            if (args.isEmpty() && !(isLast && type == String[].class) && !parameter.isFlag()) {
                 if (allowOptional && parameter.getDefaultValue() != null) {
                     args.add(parameter.getDefaultValue());
                 } else if (allowOptional && parameter.isOptional()) {
-                    Object value = parameter.isOptionalResolver() ? resolver.getContext(context) : null;
+                    Object value = parameter.isOptionalResolver() ? resolver.get(context) : null;
                     if (value == null && parameter.getClass().isPrimitive()) {
                         throw new IllegalStateException("Parameter " + parameter.getName() + " is primitive and does not support Optional.");
                     }
@@ -236,7 +242,7 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
                     return null;
                 }
             }
-            if (parameter.getValues() != null) {
+            if (parameter.getValues() != null && !parameter.isFlag()) {
                 String arg = !args.isEmpty() ? args.get(0) : "";
 
                 Set<String> possible = Sets.newHashSet();
@@ -256,7 +262,7 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
                             "{valid}", ACFUtil.join(possible, ", "));
                 }
             }
-            Object paramValue = resolver.getContext(context);
+            Object paramValue = resolver.get(context);
             //noinspection unchecked
             this.manager.conditions.validateConditions(context, paramValue);
             passedArgs.put(parameterName, paramValue);

--- a/core/src/main/java/co/aikar/commands/contexts/ContextResolver.java
+++ b/core/src/main/java/co/aikar/commands/contexts/ContextResolver.java
@@ -26,6 +26,7 @@ package co.aikar.commands.contexts;
 import co.aikar.commands.CommandExecutionContext;
 import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.InvalidCommandArgument;
+import co.aikar.commands.resolver.Resolver;
 
 /**
  * This defines a context resolver, which parses {@link T} from {@link C}.
@@ -36,7 +37,8 @@ import co.aikar.commands.InvalidCommandArgument;
  *         The type of the context which the resolver would get its data from.
  */
 @FunctionalInterface
-public interface ContextResolver <T, C extends CommandExecutionContext<?, ? extends CommandIssuer>> {
+public interface ContextResolver<T, C extends CommandExecutionContext<?, ? extends CommandIssuer>>
+        extends Resolver<T, C> {
     /**
      * Parses the context of type {@link C} into {@link T}, or throws an exception.
      *
@@ -48,5 +50,5 @@ public interface ContextResolver <T, C extends CommandExecutionContext<?, ? exte
      * @throws InvalidCommandArgument
      *         In case the context contains any discrepancies, it will throw this exception.
      */
-    T getContext(C c) throws InvalidCommandArgument;
+    T get(C c) throws InvalidCommandArgument;
 }

--- a/core/src/main/java/co/aikar/commands/flags/AbstractCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/AbstractCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,25 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import java.util.Optional;
 
-    static final String LOG_PREFIX = "[ACF] ";
+public abstract class AbstractCommandFlag<T extends CommandFlagType<T, V>, V> implements CommandFlag<T, V> {
+
+    private V value;
+
+    public AbstractCommandFlag() {
+        this(null);
+    }
+
+    public AbstractCommandFlag(V value) {
+        this.value = value;
+    }
+
+    @Override
+    public Optional<V> getValue() {
+        return Optional.of(this.value);
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/CommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/CommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,18 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import java.util.Optional;
 
-    static final String LOG_PREFIX = "[ACF] ";
+public interface CommandFlag<T extends CommandFlagType<T, V>, V> {
+
+    T getType();
+
+    Optional<V> getValue();
+
+    static boolean isCommandFlag(Class<?> clazz) {
+        return CommandFlag.class.isAssignableFrom(clazz);
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/CommandFlagResolver.java
+++ b/core/src/main/java/co/aikar/commands/flags/CommandFlagResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,13 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import co.aikar.commands.CommandExecutionContext;
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.resolver.Resolver;
 
-    static final String LOG_PREFIX = "[ACF] ";
+@FunctionalInterface
+public interface CommandFlagResolver<T, C extends CommandExecutionContext<?, ? extends CommandIssuer>>
+        extends Resolver<T, C> {
 }

--- a/core/src/main/java/co/aikar/commands/flags/CommandFlagType.java
+++ b/core/src/main/java/co/aikar/commands/flags/CommandFlagType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,16 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public interface CommandFlagType<T extends CommandFlagType<T, V>, V> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    CommandFlag<T, V> create(V value);
+
+    Class<V> getValueType();
+
+    default boolean isState() {
+        return this.getValueType() == Boolean.class;
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/CommandFlags.java
+++ b/core/src/main/java/co/aikar/commands/flags/CommandFlags.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands.flags;
+
+import co.aikar.commands.CommandExecutionContext;
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.CommandManager;
+import co.aikar.commands.LogLevel;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class CommandFlags<R extends CommandExecutionContext<?, ? extends CommandIssuer>> {
+
+    protected final CommandManager manager;
+
+    protected Map<String, CommandFlagType<?, ?>> flags = Maps.newHashMap();
+
+    protected Map<String, CommandFlagResolver<CommandFlag<?, ?>, R>> resolvers = Maps.newHashMap();
+
+    public CommandFlags(CommandManager manager) {
+        this.manager = manager;
+    }
+
+    public <V> void registerFlag(String flag,
+                                 CommandFlagType<?, V> flagType,
+                                 CommandFlagResolver<V, R> resolver) {
+        this.flags.put(flag.toLowerCase(), flagType);
+        this.resolvers.put(flag.toLowerCase(), c -> flagType.create(resolver.get(c)));
+    }
+
+    public <V> CommandFlagType<?, V> getType(String flag) {
+        flag = flag.toLowerCase();
+
+        if (this.flags.containsKey(flag))
+            return (CommandFlagType<?, V>) this.flags.get(flag);
+
+        this.manager.log(LogLevel.ERROR, "Could not find flag type",
+                new IllegalStateException("No flag type defined for " + flag));
+        return null;
+    }
+
+    public CommandFlagResolver<?, R> getResolver(String flag) {
+        flag = flag.toLowerCase();
+
+        if (this.resolvers.containsKey(flag))
+            return this.resolvers.get(flag);
+
+        this.manager.log(LogLevel.ERROR, "Could not find flag resolver",
+                new IllegalStateException("No flag resolver defined for " + flag));
+        return null;
+    }
+
+}

--- a/core/src/main/java/co/aikar/commands/flags/DoubleCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/DoubleCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,37 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class DoubleCommandFlag extends AbstractCommandFlag<DoubleCommandFlag.DoubleCommandFlagType, Double> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    public static final DoubleCommandFlagType TYPE = new DoubleCommandFlagType();
+
+    public DoubleCommandFlag() {
+        super();
+    }
+
+    public DoubleCommandFlag(Double value) {
+        super(value);
+    }
+
+    @Override
+    public DoubleCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class DoubleCommandFlagType implements CommandFlagType<DoubleCommandFlagType, Double> {
+
+        @Override
+        public CommandFlag<DoubleCommandFlagType, Double> create(Double value) {
+            return new DoubleCommandFlag(value);
+        }
+
+        @Override
+        public Class<Double> getValueType() {
+            return Double.class;
+        }
+
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/IntegerCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/IntegerCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,37 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class IntegerCommandFlag extends AbstractCommandFlag<IntegerCommandFlag.IntegerCommandFlagType, Integer> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    public static final IntegerCommandFlagType TYPE = new IntegerCommandFlagType();
+
+    public IntegerCommandFlag() {
+        super();
+    }
+
+    public IntegerCommandFlag(Integer value) {
+        super(value);
+    }
+
+    @Override
+    public IntegerCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class IntegerCommandFlagType implements CommandFlagType<IntegerCommandFlagType, Integer> {
+
+        @Override
+        public CommandFlag<IntegerCommandFlagType, Integer> create(Integer value) {
+            return new IntegerCommandFlag(value);
+        }
+
+        @Override
+        public Class<Integer> getValueType() {
+            return Integer.class;
+        }
+
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/LongCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/LongCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,37 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class LongCommandFlag extends AbstractCommandFlag<LongCommandFlag.LongCommandFlagType, Long> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    public static final LongCommandFlagType TYPE = new LongCommandFlagType();
+
+    public LongCommandFlag() {
+        super();
+    }
+
+    public LongCommandFlag(Long value) {
+        super(value);
+    }
+
+    @Override
+    public LongCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class LongCommandFlagType implements CommandFlagType<LongCommandFlagType, Long> {
+
+        @Override
+        public CommandFlag<LongCommandFlagType, Long> create(Long value) {
+            return new LongCommandFlag(value);
+        }
+
+        @Override
+        public Class<Long> getValueType() {
+            return Long.class;
+        }
+
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/StateCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/StateCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,32 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class StateCommandFlag extends AbstractCommandFlag<StateCommandFlag.StateCommandFlagType, Boolean> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    public static final StateCommandFlagType TYPE = new StateCommandFlagType();
+
+    public StateCommandFlag(Boolean value) {
+        super(value);
+    }
+
+    @Override
+    public StateCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class StateCommandFlagType implements CommandFlagType<StateCommandFlagType, Boolean> {
+
+        @Override
+        public CommandFlag<StateCommandFlagType, Boolean> create(Boolean value) {
+            return new StateCommandFlag(value);
+        }
+
+        @Override
+        public Class<Boolean> getValueType() {
+            return Boolean.class;
+        }
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/flags/StringCommandFlag.java
+++ b/core/src/main/java/co/aikar/commands/flags/StringCommandFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,37 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.flags;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class StringCommandFlag extends AbstractCommandFlag<StringCommandFlag.StringCommandFlagType, String> {
 
-    static final String LOG_PREFIX = "[ACF] ";
+    public static final StringCommandFlagType TYPE = new StringCommandFlagType();
+
+    public StringCommandFlag() {
+        super();
+    }
+
+    public StringCommandFlag(String value) {
+        super(value);
+    }
+
+    @Override
+    public StringCommandFlagType getType() {
+        return TYPE;
+    }
+
+    static class StringCommandFlagType implements CommandFlagType<StringCommandFlagType, String> {
+
+        @Override
+        public CommandFlag<StringCommandFlagType, String> create(String value) {
+            return new StringCommandFlag(value);
+        }
+
+        @Override
+        public Class<String> getValueType() {
+            return String.class;
+        }
+
+    }
+
 }

--- a/core/src/main/java/co/aikar/commands/resolver/Resolver.java
+++ b/core/src/main/java/co/aikar/commands/resolver/Resolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,15 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.resolver;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+import co.aikar.commands.CommandExecutionContext;
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.InvalidCommandArgument;
 
-    static final String LOG_PREFIX = "[ACF] ";
+@FunctionalInterface
+public interface Resolver<T, C extends CommandExecutionContext<?, ? extends CommandIssuer>> {
+
+    T get(C c) throws InvalidCommandArgument;
+
 }

--- a/core/src/main/java/co/aikar/commands/resolver/Test.java
+++ b/core/src/main/java/co/aikar/commands/resolver/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -21,11 +21,8 @@
  *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package co.aikar.commands;
+package co.aikar.commands.resolver;
 
-public enum LogLevel {
-    INFO,
-    ERROR;
+public class Test {
 
-    static final String LOG_PREFIX = "[ACF] ";
 }

--- a/example/src/main/java/co/aikar/acfexample/ACFExample.java
+++ b/example/src/main/java/co/aikar/acfexample/ACFExample.java
@@ -27,8 +27,13 @@ import co.aikar.commands.BukkitCommandManager;
 import co.aikar.commands.ConditionFailedException;
 import co.aikar.commands.MessageKeys;
 import co.aikar.commands.MessageType;
+import co.aikar.commands.flags.PlayerCommandFlag;
+import co.aikar.commands.flags.StringCommandFlag;
 import com.google.common.collect.Lists;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
 
 public final class ACFExample extends JavaPlugin {
 
@@ -105,6 +110,16 @@ public final class ACFExample extends JavaPlugin {
         commandManager.setDefaultExceptionHandler((command, registeredCommand, sender, args, t) -> {
             getLogger().warning("Error occured while executing command " + command.getName());
             return false; // mark as unhandeled, sender will see default message
+        });
+
+        // 10: Register flags
+        commandManager.getCommandFlags().registerFlag("message", StringCommandFlag.TYPE, c -> {
+            return c.getCommandFlags().get("message");
+        });
+        commandManager.getCommandFlags().registerFlag("player", PlayerCommandFlag.TYPE, c -> {
+            Map<String, String> flags = c.getCommandFlags();
+
+            return flags.containsKey("player") ? Bukkit.getPlayer(flags.get("player")) : null;
         });
     }
 

--- a/example/src/main/java/co/aikar/acfexample/SomeCommand.java
+++ b/example/src/main/java/co/aikar/acfexample/SomeCommand.java
@@ -30,10 +30,13 @@ import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Values;
 import co.aikar.commands.contexts.OnlinePlayer;
+import co.aikar.commands.flags.PlayerCommandFlag;
+import co.aikar.commands.flags.StringCommandFlag;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -69,6 +72,19 @@ public class SomeCommand extends BaseCommand {
         sender.sendMessage("Test String 1: " + testString);
         sender.sendMessage("Test String 2: " + testString2);
         sender.sendMessage("Test String 3: " + testString3);
+    }
+
+    // Simple example for use flags
+    @Subcommand("hello")
+    public void flagTest(CommandSender sender,
+                         @Flags("message") StringCommandFlag helloMessage) {
+        sender.sendMessage(helloMessage.getValue().orElse("Hello, my friend!"));
+    }
+    
+    @Subcommand("name")
+    public void flagTest2(Player sender,
+                          @Flags("player") PlayerCommandFlag playerFlag) {
+        sender.sendMessage("name: " + playerFlag.getValue().orElse(sender).getName());
     }
 
     // %testcmd was defined in ACFExample plugin and defined as "test4|foobar|barbaz"

--- a/jda/src/main/java/co/aikar/commands/JDACommandExecutionContext.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandExecutionContext.java
@@ -4,7 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 public class JDACommandExecutionContext extends CommandExecutionContext<JDACommandExecutionContext, JDACommandEvent> {
-    JDACommandExecutionContext(RegisteredCommand cmd, CommandParameter param, JDACommandEvent sender, List<String> args, int index, Map<String, Object> passedArgs) {
-        super(cmd, param, sender, args, index, passedArgs);
+    JDACommandExecutionContext(RegisteredCommand cmd, CommandParameter param, JDACommandEvent sender, List<String> args,
+                               Map<String, String> commandFlags, int index, Map<String, Object> passedArgs) {
+        super(cmd, param, sender, args, commandFlags, index, passedArgs);
     }
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -199,8 +199,11 @@ public class JDACommandManager extends CommandManager<
     }
 
     @Override
-    public CommandExecutionContext createCommandContext(RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args, int i, Map<String, Object> passedArgs) {
-        return new JDACommandExecutionContext(command, parameter, (JDACommandEvent) sender, args, i, passedArgs);
+    public CommandExecutionContext createCommandContext
+            (RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args,
+             Map<String, String> commandFlags, int i, Map<String, Object> passedArgs) {
+        return new JDACommandExecutionContext(command, parameter, (JDACommandEvent) sender, args,
+                commandFlags, i, passedArgs);
     }
 
     @Override

--- a/sponge/src/main/java/co/aikar/commands/SpongeCommandExecutionContext.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeCommandExecutionContext.java
@@ -33,8 +33,8 @@ import java.util.Map;
 public class SpongeCommandExecutionContext extends CommandExecutionContext<SpongeCommandExecutionContext, SpongeCommandIssuer> {
 
     SpongeCommandExecutionContext(RegisteredCommand cmd, CommandParameter param, SpongeCommandIssuer sender, List<String> args,
-                                  int index, Map<String, Object> passedArgs) {
-        super(cmd, param, sender, args, index, passedArgs);
+                                  Map<String, String> commandFlags, int index, Map<String, Object> passedArgs) {
+        super(cmd, param, sender, args, commandFlags, index, passedArgs);
     }
 
     public CommandSource getSource() {

--- a/sponge/src/main/java/co/aikar/commands/SpongeCommandManager.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeCommandManager.java
@@ -152,8 +152,11 @@ public class SpongeCommandManager extends CommandManager<
     }
 
     @Override
-    public SpongeCommandExecutionContext createCommandContext(RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args, int i, Map<String, Object> passedArgs) {
-        return new SpongeCommandExecutionContext(command, parameter, (SpongeCommandIssuer) sender, args, i, passedArgs);
+    public SpongeCommandExecutionContext createCommandContext
+            (RegisteredCommand command, CommandParameter parameter, CommandIssuer sender, List<String> args,
+             Map<String, String> commandFlags, int i, Map<String, Object> passedArgs) {
+        return new SpongeCommandExecutionContext(command, parameter, (SpongeCommandIssuer) sender, args,
+                commandFlags, i, passedArgs);
     }
 
     @Override


### PR DESCRIPTION
 Users can create flags that players can use when invoking a command

### For example:

`@CommandAlias("silent")`
`public void info(CommandSender sender, @Flags("s") StateCommandFlag silent) {`
`    sender.sendMessage("Is sneaky: " + silent.getValue().orElse(false));`
`}`

If player executes `/silent` he receives "Is sneaky: false" message in chat
If player executes `/silent -s` he receives "is sneaky: true" message in chat

**Register a flag:**
`commandManager.getCommandFlags().registerFlag("s", StateCommandFlag.TYPE, c -> {`
`    return c.getCommandFlags().containsKey("s");`
`});`

### Example with parameters:

`commandManager.getCommandFlags().registerFlag("player", PlayerCommandFlag.TYPE, c -> {`
`    Map<String, String> flags = c.getCommandFlags();`
`    return flags.containsKey("player") ? Bukkit.getPlayer(flags.get("player")) : null;`
`});`

`@Subcommand("info")`
`public void info(CommandSender sender, @Flags("player") PlayerCommandFlag playerFlag) {`
`    if (!(sender instanceof Player) && !playerFlag.getValue().isPresent()) {`
`        sender.sendMessage("Please, specify a player: /info -player [nick]");`
`        return;`
`    }`
`    sender.sendMessage("Player name: " + playerFlag.getValue().orElse((Player) sender).getName());`
`}`

If console executes `/info` it receives "Please, specify a player: /info -player [nick]" message in chat
If player executes `/info` he receives "Player name: <player_name>" message in chat
If player or console executes `/info -player ZENEGIX` he receives "Player name: ZENEGIX" message in chat