### PR TITLE
Replace Guava multimaps (and Iterables)

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
@@ -23,7 +23,6 @@
 
 package co.aikar.commands;
 
-import com.google.common.collect.Iterables;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -281,7 +280,7 @@ public class ACFBukkitUtil {
                         "{search}", name);
                 return null;
             } else {
-                Player player = Iterables.getOnlyElement(confirmList);
+                Player player = ACFUtil.getFirstElement(confirmList);
                 issuer.sendInfo(MinecraftMessageKeys.PLAYER_IS_VANISHED_CONFIRM, "{vanished}", player.getName());
                 return null;
             }

--- a/bukkit/src/main/java/co/aikar/commands/BukkitRootCommand.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitRootCommand.java
@@ -23,8 +23,7 @@
 
 package co.aikar.commands;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
@@ -36,7 +35,7 @@ public class BukkitRootCommand extends Command implements RootCommand {
     private final BukkitCommandManager manager;
     private final String name;
     private BaseCommand defCommand;
-    private SetMultimap<String, RegisteredCommand> subCommands = HashMultimap.create();
+    private MapSet<String, RegisteredCommand> subCommands = new MapSet<>();
     private List<BaseCommand> children = new ArrayList<>();
     boolean isRegistered = false;
 
@@ -79,7 +78,7 @@ public class BukkitRootCommand extends Command implements RootCommand {
     }
 
     @Override
-    public SetMultimap<String, RegisteredCommand> getSubCommands() {
+    public MapSet<String, RegisteredCommand> getSubCommands() {
         return this.subCommands;
     }
 

--- a/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
@@ -23,8 +23,7 @@
 
 package co.aikar.commands;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
@@ -37,7 +36,7 @@ public class BungeeRootCommand extends Command implements RootCommand, TabExecut
     private final BungeeCommandManager manager;
     private final String name;
     private BaseCommand defCommand;
-    private SetMultimap<String, RegisteredCommand> subCommands = HashMultimap.create();
+    private MapSet<String, RegisteredCommand> subCommands = new MapSet<>();
     private List<BaseCommand> children = new ArrayList<>();
     boolean isRegistered = false;
 
@@ -67,7 +66,7 @@ public class BungeeRootCommand extends Command implements RootCommand, TabExecut
     }
 
     @Override
-    public SetMultimap<String, RegisteredCommand> getSubCommands() {
+    public MapSet<String, RegisteredCommand> getSubCommands() {
         return subCommands;
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,12 @@
     <dependencies>
         <dependency>
             <groupId>co.aikar</groupId>
+            <artifactId>MapSet</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>co.aikar</groupId>
             <artifactId>Table</artifactId>
             <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>

--- a/core/src/main/java/co/aikar/commands/ACFUtil.java
+++ b/core/src/main/java/co/aikar/commands/ACFUtil.java
@@ -33,6 +33,7 @@ import java.text.Normalizer.Form;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
@@ -586,6 +587,16 @@ public final class ACFUtil {
         }
 
         return list;
+    }
+
+    public static <T> T getFirstElement(Iterable<T> iterable) {
+        Iterator<T> iterator = iterable.iterator();
+        T first = iterator.next();
+        if (!iterator.hasNext()) {
+            return first;
+        }
+
+        throw new IllegalArgumentException("Expected one element in iterable");
     }
 
     private static class ApplyModifierToNumber {

--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -35,7 +35,6 @@ import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.UnknownHandler;
 import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 import org.jetbrains.annotations.Nullable;
 
@@ -614,7 +613,7 @@ public abstract class BaseCommand {
             if (!cmds.isEmpty()) {
                 RegisteredCommand cmd = null;
                 if (cmds.size() == 1) {
-                    cmd = Iterables.getOnlyElement(cmds);
+                    cmd = ACFUtil.getFirstElement(cmds);
                 } else {
                     Optional<RegisteredCommand> optCmd = cmds.stream().filter(c -> {
                         int required = c.requiredResolvers;
@@ -718,9 +717,9 @@ public abstract class BaseCommand {
             if (search != null) {
                 cmds.addAll(completeCommand(issuer, search.cmd, Arrays.copyOfRange(args, search.argIndex, args.length), commandLabel, isAsync));
             } else if (subCommands.get(CATCHUNKNOWN).size() == 1) {
-                cmds.addAll(completeCommand(issuer, Iterables.getOnlyElement(subCommands.get(CATCHUNKNOWN)), args, commandLabel, isAsync));
+                cmds.addAll(completeCommand(issuer, ACFUtil.getFirstElement(subCommands.get(CATCHUNKNOWN)), args, commandLabel, isAsync));
             } else if (subCommands.get(DEFAULT).size() == 1) {
-                cmds.addAll(completeCommand(issuer, Iterables.getOnlyElement(subCommands.get(DEFAULT)), args, commandLabel, isAsync));
+                cmds.addAll(completeCommand(issuer, ACFUtil.getFirstElement(subCommands.get(DEFAULT)), args, commandLabel, isAsync));
             }
 
             return filterTabComplete(args[args.length - 1], cmds);

--- a/core/src/main/java/co/aikar/commands/CommandHelp.java
+++ b/core/src/main/java/co/aikar/commands/CommandHelp.java
@@ -23,7 +23,7 @@
 
 package co.aikar.commands;
 
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -56,7 +56,7 @@ public class CommandHelp {
         this.commandName = rootCommand.getCommandName();
 
 
-        SetMultimap<String, RegisteredCommand> subCommands = rootCommand.getSubCommands();
+        MapSet<String, RegisteredCommand> subCommands = rootCommand.getSubCommands();
         Set<RegisteredCommand> seen = new HashSet<>();
         
         if (!rootCommand.getDefCommand().hasHelpCommand) {
@@ -64,7 +64,7 @@ public class CommandHelp {
             seen.add(rootCommand.getDefaultRegisteredCommand());
         }
         
-        subCommands.entries().forEach(e -> {
+        subCommands.forEach(e -> {
             String key = e.getKey();
             if (key.equals(BaseCommand.DEFAULT) || key.equals(BaseCommand.CATCHUNKNOWN)) {
                 return;

--- a/core/src/main/java/co/aikar/commands/Locales.java
+++ b/core/src/main/java/co/aikar/commands/Locales.java
@@ -26,8 +26,7 @@ package co.aikar.commands;
 import co.aikar.locales.LocaleManager;
 import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -79,7 +78,7 @@ public class Locales {
 
     private final CommandManager manager;
     private final LocaleManager<CommandIssuer> localeManager;
-    private final Map<ClassLoader, SetMultimap<String, Locale>> loadedBundles = new HashMap<>();
+    private final Map<ClassLoader, MapSet<String, Locale>> loadedBundles = new HashMap<>();
     private final List<ClassLoader> registeredClassLoaders = new ArrayList<>();
 
     public Locales(CommandManager manager) {
@@ -107,8 +106,8 @@ public class Locales {
         //noinspection unchecked
         Set<Locale> supportedLanguages = manager.getSupportedLanguages();
         for (Locale locale : supportedLanguages) {
-            for(SetMultimap<String, Locale> localeData: this.loadedBundles.values()) {
-                for (String bundleName : new HashSet<>(localeData.keys())) {
+            for(MapSet<String, Locale> localeData: this.loadedBundles.values()) {
+                for (String bundleName : new HashSet<>(localeData.keySet())) {
                     addMessageBundle(bundleName, locale);
                 }
             }
@@ -138,10 +137,10 @@ public class Locales {
     }
 
     public boolean addMessageBundle(ClassLoader classLoader, String bundleName, Locale locale) {
-        SetMultimap<String, Locale> classLoadersLocales = this.loadedBundles.getOrDefault(classLoader, HashMultimap.create());
-        if(!classLoadersLocales.containsEntry(bundleName, locale)) {
+        MapSet<String, Locale> classLoadersLocales = this.loadedBundles.getOrDefault(classLoader, new MapSet<>());
+        if(!classLoadersLocales.get(bundleName).contains(locale)) {
             if(this.localeManager.addMessageBundle(classLoader, bundleName, locale)) {
-                classLoadersLocales.put(bundleName, locale);
+                classLoadersLocales.add(bundleName, locale);
                 this.loadedBundles.put(classLoader, classLoadersLocales);
                 return true;
             }

--- a/core/src/main/java/co/aikar/commands/RootCommand.java
+++ b/core/src/main/java/co/aikar/commands/RootCommand.java
@@ -24,7 +24,7 @@
 package co.aikar.commands;
 
 import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -35,12 +35,12 @@ public interface RootCommand {
     void addChild(BaseCommand command);
     CommandManager getManager();
 
-    SetMultimap<String, RegisteredCommand> getSubCommands();
+    MapSet<String, RegisteredCommand> getSubCommands();
     List<BaseCommand> getChildren();
 
     String getCommandName();
-    default void addChildShared(List<BaseCommand> children, SetMultimap<String, RegisteredCommand> subCommands, BaseCommand command) {
-        command.subCommands.entries().forEach(e -> {
+    default void addChildShared(List<BaseCommand> children, MapSet<String, RegisteredCommand> subCommands, BaseCommand command) {
+        command.subCommands.forEach(e -> {
             String key = e.getKey();
             RegisteredCommand registeredCommand = e.getValue();
             if (key.equals(BaseCommand.DEFAULT) || key.equals(BaseCommand.CATCHUNKNOWN)) {
@@ -55,7 +55,7 @@ public interface RootCommand {
                     return;
                 }
             }
-            subCommands.put(key, registeredCommand);
+            subCommands.add(key, registeredCommand);
         });
 
         children.add(command);

--- a/jda/src/main/java/co/aikar/commands/JDARootCommand.java
+++ b/jda/src/main/java/co/aikar/commands/JDARootCommand.java
@@ -1,7 +1,6 @@
 package co.aikar.commands;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +11,7 @@ public class JDARootCommand implements RootCommand {
     boolean isRegistered = false;
     private JDACommandManager manager;
     private BaseCommand defCommand;
-    private SetMultimap<String, RegisteredCommand> subCommands = HashMultimap.create();
+    private MapSet<String, RegisteredCommand> subCommands = new MapSet<>();
     private List<BaseCommand> children = new ArrayList<>();
 
     JDARootCommand(JDACommandManager manager, String name) {
@@ -35,7 +34,7 @@ public class JDARootCommand implements RootCommand {
     }
 
     @Override
-    public SetMultimap<String, RegisteredCommand> getSubCommands() {
+    public MapSet<String, RegisteredCommand> getSubCommands() {
         return this.subCommands;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,12 +128,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>15.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>15.0</version>

--- a/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
+++ b/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
@@ -1,6 +1,5 @@
 package co.aikar.commands;
 
-import com.google.common.collect.Iterables;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
@@ -45,7 +44,7 @@ public class ACFSpongeUtil {
                         "{search}", name);
                 return null;
             } else {
-                Player player = Iterables.getOnlyElement(confirmList);
+                Player player = ACFUtil.getFirstElement(confirmList);
                 issuer.sendInfo(MinecraftMessageKeys.PLAYER_IS_VANISHED_CONFIRM, "{vanished}", player.getName());
                 return null;
             }

--- a/sponge/src/main/java/co/aikar/commands/SpongeRootCommand.java
+++ b/sponge/src/main/java/co/aikar/commands/SpongeRootCommand.java
@@ -23,8 +23,7 @@
 
 package co.aikar.commands;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import co.aikar.util.MapSet;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
@@ -44,7 +43,7 @@ public class SpongeRootCommand implements CommandCallable, RootCommand {
     private final SpongeCommandManager manager;
     private final String name;
     private BaseCommand defCommand;
-    private SetMultimap<String, RegisteredCommand> subCommands = HashMultimap.create();
+    private MapSet<String, RegisteredCommand> subCommands = new MapSet<>();
     private List<BaseCommand> children = new ArrayList<>();
     boolean isRegistered = false;
 
@@ -115,7 +114,7 @@ public class SpongeRootCommand implements CommandCallable, RootCommand {
     }
 
     @Override
-    public SetMultimap<String, RegisteredCommand> getSubCommands() {
+    public MapSet<String, RegisteredCommand> getSubCommands() {
         return subCommands;
     }
 


### PR DESCRIPTION
~~Only thing which isn't done yet is [Locales.java](https://github.com/aikar/commands/blob/3c979a9ef24dc62e6611832cc97ef25f77afec2d/core/src/main/java/co/aikar/commands/Locales.java), since original code calls to `containsEntry(K, V)` and there's no replacement for it in `co.aikar.util.MapSet`~~ (`containsEntry(K, V)` == `get(K).contains(V)`)

Ready for a review.