### PR TITLE
Improve logging concerning command replacements

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandReplacements.java
+++ b/core/src/main/java/co/aikar/commands/CommandReplacements.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.AbstractMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -53,11 +54,6 @@ public class CommandReplacements {
     }
 
     public String addReplacement(String key, String val) {
-        if (this.manager.hasRegisteredCommands()) {
-            this.manager.log(LogLevel.ERROR, "You are registering replacements after you have registered your commands!");
-            this.manager.log(LogLevel.ERROR, "This is not allowed, and this replacement (" + key + ") will not work for any previously registered command.");
-        }
-
         return addReplacement0(key, val);
     }
 
@@ -83,6 +79,13 @@ public class CommandReplacements {
 
         for (Map.Entry<Pattern, String> entry : replacements.values()) {
             text = entry.getKey().matcher(text).replaceAll(entry.getValue());
+        }
+
+        // check for unregistered replacements
+        Pattern pattern = Pattern.compile("%.[^\\s]*");
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            this.manager.log(LogLevel.ERROR, "Found unregistered replacement: " + matcher.group());
         }
 
         return manager.getLocales().replaceI18NStrings(text);


### PR DESCRIPTION
The code is now checking for placeholders, that are not replaced. This would also warn the dev if he completely forgets to register a replacement. 
The downside of this is, that any %.* kind of pattern, that is NOT supposed to be a replacement will cause an error message. But since I couldn't come up for a reason to include % in any of the Annotation values other than a replacement, I decided this is much easier than checking all "old" commands when a replacement is registered.
Alternatively, I could collect all these unreplaced replacements and check against the collection when a new one is registered. This would not warn a dev that forgot to register the replacement, but on the other hand still allows the use of %. Please tell me what you think.

resolves #160 