### PR TITLE
Add unregister method for JDA

### DIFF
--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -161,6 +161,17 @@ public class JDACommandManager extends CommandManager<
         }
     }
 
+    public void unregisterCommand(BaseCommand command) {
+        for (Map.Entry<String, RootCommand> entry : command.registeredCommands.entrySet()) {
+            String commandName = entry.getKey().toLowerCase();
+            JDARootCommand cmd = (JDARootCommand) entry.getValue();
+            if (cmd.isRegistered) {
+                cmd.isRegistered = false;
+                commands.remove(commandName);
+            }
+        }
+    }
+
     @Override
     public boolean hasRegisteredCommands() {
         return !this.commands.isEmpty();

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -163,11 +163,12 @@ public class JDACommandManager extends CommandManager<
 
     public void unregisterCommand(BaseCommand command) {
         for (Map.Entry<String, RootCommand> entry : command.registeredCommands.entrySet()) {
-            String commandName = entry.getKey().toLowerCase();
-            JDARootCommand cmd = (JDARootCommand) entry.getValue();
-            if (cmd.isRegistered) {
-                cmd.isRegistered = false;
-                commands.remove(commandName);
+            String jdaCommandName = entry.getKey().toLowerCase();
+            JDARootCommand jdaCommand = (JDARootCommand) entry.getValue();
+            jdaCommand.getSubCommands().values().removeAll(command.subCommands.values());
+            if (jdaCommand.isRegistered && jdaCommand.getSubCommands().isEmpty()) {
+                jdaCommand.isRegistered = false;
+                commands.remove(jdaCommandName);
             }
         }
     }


### PR DESCRIPTION
This PR is to allow users to unregister commands from the `JDACommandManager`

Currently slightly flawed, needs research. When re-registering it spits out a load of messages like so:
```
SEVERE: [ACF] ACF Error: settings registered subcommand boss role for root command settings - but it is already defined in settings
Sep 20, 2018 3:58:31 AM com.algorithmjunkie.freelance.gachapon.acf.JDACommandManager log
SEVERE: [ACF] 2 subcommands of the same prefix may not be spread over 2 different classes. Ignoring this.
```

Not sure if this is just for me, or if it's for all.