### PR TITLE
Implement Named Parameters and Per Parameter Tab Completion

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -710,7 +710,6 @@ public abstract class BaseCommand {
 
             final CommandSearch search = findSubCommand(args, true);
 
-
             final List<String> cmds = new ArrayList<>();
 
             if (search != null) {
@@ -772,7 +771,7 @@ public abstract class BaseCommand {
      * @return All results to complete the command.
      */
     private List<String> completeCommand(CommandIssuer issuer, RegisteredCommand cmd, String[] args, String commandLabel, boolean isAsync) {
-        if (!cmd.hasPermission(issuer) || args.length > cmd.consumeInputResolvers || args.length == 0 || cmd.complete == null) {
+        if (!cmd.hasPermission(issuer) || args.length == 0 || cmd.complete == null) {
             return Collections.emptyList();
         }
 

--- a/core/src/main/java/co/aikar/commands/CommandCompletions.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletions.java
@@ -170,20 +170,21 @@ public class CommandCompletions <C extends CommandCompletionContext> {
 
     @NotNull
     List<String> of(RegisteredCommand cmd, CommandIssuer sender, String[] args, boolean isAsync) {
-        String[] completions = ACFPatterns.SPACE.split(cmd.complete);
-        final int argIndex = args.length - 1;
+        RegisteredCommand.CommandData commandData = cmd.parseArguments(args);
 
-        String input = args[argIndex];
+        final int argIndex = commandData.args.size() - 1;
+        String input = argIndex >= 0 ? commandData.args.get(argIndex) : "";
 
-        String completion = argIndex < completions.length ? completions[argIndex] : null;
-        if (completion == null && completions.length > 0) {
-            completion = completions[completions.length - 1];
+        // Check if its a switch
+        if (commandData.isSwitch) {
+            return commandData.switches;
         }
-        if (completion == null) {
+
+        if (commandData.complete == null) {
             return Collections.singletonList(input);
         }
 
-        return getCompletionValues(cmd, sender, completion, args, isAsync);
+        return getCompletionValues(cmd, sender, commandData.complete, args, isAsync);
     }
 
     List<String> getCompletionValues(RegisteredCommand command, CommandIssuer sender, String completion, String[] args, boolean isAsync) {

--- a/core/src/main/java/co/aikar/commands/CommandParameter.java
+++ b/core/src/main/java/co/aikar/commands/CommandParameter.java
@@ -23,11 +23,13 @@
 
 package co.aikar.commands;
 
+import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Switch;
 import co.aikar.commands.annotation.Syntax;
 import co.aikar.commands.annotation.Values;
 import co.aikar.commands.contexts.ContextResolver;
@@ -36,6 +38,7 @@ import co.aikar.commands.contexts.IssuerOnlyContextResolver;
 import co.aikar.commands.contexts.OptionalContextResolver;
 
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,6 +55,8 @@ public class CommandParameter <CEC extends CommandExecutionContext<CEC, ? extend
     private String defaultValue;
     private String syntax;
     private String conditions;
+    private String complete;
+    private String switches;
     private boolean requiresInput;
     private boolean commandIssuer;
     private String[] values;
@@ -71,6 +76,8 @@ public class CommandParameter <CEC extends CommandExecutionContext<CEC, ? extend
         this.defaultValue = annotations.getAnnotationValue(param, Default.class, Annotations.REPLACEMENTS | (type != String.class ? Annotations.NO_EMPTY : 0));
         this.description = annotations.getAnnotationValue(param, Description.class, Annotations.REPLACEMENTS | Annotations.DEFAULT_EMPTY);
         this.conditions = annotations.getAnnotationValue(param, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.complete = annotations.getAnnotationValue(param, CommandCompletion.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.switches = annotations.getAnnotationValue(param, Switch.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
 
         //noinspection unchecked
         this.resolver = manager.getCommandContexts().getResolver(type);
@@ -94,9 +101,17 @@ public class CommandParameter <CEC extends CommandExecutionContext<CEC, ? extend
             this.syntax = annotations.getAnnotationValue(param, Syntax.class);
             if (syntax == null) {
                 if (!requiresInput && canConsumeInput) {
-                    this.syntax = "[" + name + "]";
+                    if (switches != null) {
+                        this.syntax = "[-" + switches.split(",")[0] + " <" + name + ">]";
+                    } else {
+                        this.syntax = "[" + name + "]";
+                    }
                 } else if (requiresInput) {
-                    this.syntax = "<" + name + ">";
+                    if (switches != null) {
+                        this.syntax = "[-" + switches.split(",")[0] + "] " + "<" + name + ">";
+                    } else {
+                        this.syntax = "<" + name + ">";
+                    }
                 }
             }
         }
@@ -253,5 +268,25 @@ public class CommandParameter <CEC extends CommandExecutionContext<CEC, ? extend
 
     public void setConditions(String conditions) {
         this.conditions = conditions;
+    }
+
+    public String getComplete() {
+        return complete;
+    }
+
+    public void setComplete(String complete) {
+        this.complete = complete;
+    }
+
+    public String getSwitches() {
+        return switches;
+    }
+
+    public void setSwitches(String value) {
+        this.switches = value;
+    }
+
+    public boolean hasSwitch(String value) {
+        return switches != null && Arrays.asList(switches.split(",")).contains(value);
     }
 }

--- a/core/src/main/java/co/aikar/commands/annotation/Switch.java
+++ b/core/src/main/java/co/aikar/commands/annotation/Switch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ * Copyright (c) 2016-2018 Daniel Ennis (Aikar) - MIT License
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the
@@ -29,20 +29,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Many implementation platforms have a concept of "Tab Completions",
- * where pressing tab will give suggestions on what you can input.
- *
- * This annotation specifies either static completion values,
- * or special @codes that let you define Completion Handlers to dynamically
- * populate completion values.
- *
- * If used on a parameter it provides completion(s) for that parameter and will not
- * consume any provided on the Method
- *
- * @see {@link co.aikar.commands.CommandCompletions}
+ * Sets the name that the parameter can be accessed with
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.PARAMETER})
-public @interface CommandCompletion {
+public @interface Switch {
     String value();
 }


### PR DESCRIPTION
# Overview
Provides both Named Parameters through the `@Switch` annotation as well as per parameter TabCompletion

A parameter can optionally be annotated with `@Switch` to provide one or more names it can be referred by. It can then be used anywhere before its normal position upto and including its normal position by passing "-{switch name} {value}" in the command. It can also be used normally by position as well without the switch name.

Due to the nature of how Tab completions work, a Switch MUST use the parameter CommandCompletion annotation to provide tab completions, otherwise it will be assumed to have none in those positions. Method Level CommandCompletion annotations will be respected as well.

Both execution and tab completion use a method parseArgument to ensure both follow the same parsing rules.

# Example
```JAVA
    @Subcommand("open|o")
    @Description("Open Menu")
    @CommandCompletion("@menulist")
    public void onOpen(
        CommandSender sender,
        String menuItem,
        @Switch("player,p") @CommandCompletion("@players") OnlinePlayer player,
        @Switch("title") @CommandCompletion("title1|title2"") String title)
```

This will allow the following to work:
```
/cmd open mainmenu playername title1
/cmd open -player playername mainmenu title1
/cmd open -title title1 mainmenu playername
/cmd open -title title1 -player playername mainmenu
/cmd open mainmenu -player playername -title title1
/cmd open mainmenu playername -title title1
```

Whilst typing, when a '-' is detected, tab completion will show a completion list of unused switches. This will be reduced as switches are used or the parameters providing the switch are resolved by position. So in the 4th example when starting to type "-player" it will only show "-player" on the tab completion, whereas before typing "-title" it will show both options. In the 6th example when starting to type '-title' it will only show '-title' as player has already been satisfied by position.

After a switch is typed its own command completions will be provided.

# How its done
A new method to RegisterdedCommand, parseArgument, is used to take a list of arguments and return the current completion, the list of parameters (in the order detected from the arguments, so not necessarily in proper parameter order), a list of unused switches, and if the current argument is potentially a switch (allows a "-" sign to be used as an argument to a switch without it thinking its a new switch).

Both TabCompletion and Execution use this to resolve the arguments to ensure that both operate the same way.

# Reason for requiring Per Parameter Tab Completion

There some challenges to a Switch with tab completion. One of the biggest ones is that an IssuerAwareContext does not have to consume any arguments (For example a Player.class will consume its argument if there is a Flag("other") provided, otherwise it does not), which also means it does not consume tab completions. This makes it impossible to know real time which tab completions to move using position only. 

In order to satisfy as many of the requirements for this as possible with fewest changes, the easiest option is to require that a per-parameter tab completion is provided for a Switch.

For example:
```JAVA
    @Subcommand("open|o")
    @Description("Open Menu")
    @CommandCompletion("@players test1|test2")
    public void onOpen(
        CommandSender sender,
        Player player1
        @Flag("other") Player player 2
        @Switch("test,t") String test)
```
it is impossible to know that the `@players` belongs to player2 and not player1 without knowing that a Player context uses a flag to change its behaviour. This means typing '-test', it is hard to know that 'test1|test2' belongs to that parameter.

The only option is if parameters were actively involved in tab completion or declared the number of arguments they consume upfront. This is not easy to satsify in a backwards compatible method.



# Todo
* [ ] Maybe a flag to force a switch to be named rather than satisfied by position (IE: `@Switch("option", true)`) with false by default to allow it to satsify either by position or name. I'm not too sure if this is needed or not.

* [ ] Handle `@Optional` and `@Default` if it doesn't already work
