### PR TITLE
Replace Jodah's ExpiringMap with Guava's Cache

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,12 +52,6 @@
             <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>net.jodah</groupId>
-            <artifactId>expiringmap</artifactId>
-            <version>0.5.8</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/src/main/java/co/aikar/commands/ACFPatterns.java
+++ b/core/src/main/java/co/aikar/commands/ACFPatterns.java
@@ -23,8 +23,7 @@
 
 package co.aikar.commands;
 
-import net.jodah.expiringmap.ExpirationPolicy;
-import net.jodah.expiringmap.ExpiringMap;
+import com.google.common.cache.CacheBuilder;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -51,14 +50,10 @@ final class ACFPatterns {
     public static final Pattern I18N_STRING = Pattern.compile("\\{@@(?<key>.+?)}", Pattern.CASE_INSENSITIVE);
 
 
-
-    private ACFPatterns() {}
-    @SuppressWarnings("Convert2MethodRef")
-    static final Map<String, Pattern> patternCache = ExpiringMap.builder()
-            .maxSize(200)
-            .expiration(1, TimeUnit.HOURS)
-            .expirationPolicy(ExpirationPolicy.ACCESSED)
-            .build();
+    static final Map<String, Pattern> patternCache = CacheBuilder.newBuilder()
+            .maximumSize(200)
+            .expireAfterAccess(1, TimeUnit.HOURS)
+            .<String, Pattern>build().asMap();
 
     /**
      * Gets a pattern and compiles it.


### PR DESCRIPTION
There is no need to keep Jodah ExpiringMap dependency for the project as it can be painlessly replaced with Guava's Cache while the latest is an already used dependency.
This change is split on three commits.
1. The first should **never** brake anything
2. The second one would break *only* build's which relied on Jodah taken implicitly from `acf-core`
3. The third one would also have zero impact except fot the previous case and external usage of package-private `patternCache` (BTW why is it even `package-private?` :) ) which is very unlikely