### PR TITLE
BaseCommand#hasPermission checks the required permissions

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -908,7 +908,7 @@ public abstract class BaseCommand {
     }
 
     public boolean hasPermission(CommandIssuer issuer) {
-        return getRequiredPermissions().stream().allMatch(permission -> manager.hasPermission(issuer, permission)) && (parentCommand == null || parentCommand.hasPermission(issuer));
+        return getRequiredPermissions().stream().allMatch(permission -> manager.hasPermission(issuer, permission));
     }
 
     public Set<String> getRequiredPermissions() {

--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -160,6 +160,11 @@ public abstract class BaseCommand {
     @Nullable
     private String parentSubcommand;
 
+    /**
+     * The permissions of the command.
+     */
+    private final Set<String> permissions = new HashSet<>();
+
     public BaseCommand() {
     }
 
@@ -248,6 +253,7 @@ public abstract class BaseCommand {
         this.conditions = annotations.getAnnotationValue(self, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
 
         registerSubcommands();
+        registerPermissions();
         registerSubclasses(cmd);
 
         if (cmdAliases != null) {
@@ -366,6 +372,19 @@ public abstract class BaseCommand {
             if (Objects.equals(method.getDeclaringClass(), this.getClass()) && sublist != null) {
                 registerSubcommand(method, sublist);
             }
+        }
+    }
+
+    /**
+     * This registers all the permissions required to execute this command.
+     */
+    private void registerPermissions() {
+        this.permissions.clear();
+        if (this.permission != null && !this.permission.isEmpty()) {
+            this.permissions.addAll(Arrays.asList(ACFPatterns.COMMA.split(this.permission)));
+        }
+        if (this.parentCommand != null) {
+            this.permissions.addAll(this.parentCommand.getRequiredPermissions());
         }
     }
 
@@ -908,19 +927,11 @@ public abstract class BaseCommand {
     }
 
     public boolean hasPermission(CommandIssuer issuer) {
-        return getRequiredPermissions().stream().allMatch(permission -> manager.hasPermission(issuer, permission));
+        return getRequiredPermissions().isEmpty() || getRequiredPermissions().stream().allMatch(permission -> manager.hasPermission(issuer, permission));
     }
 
     public Set<String> getRequiredPermissions() {
-        Set<String> permissions = new HashSet<>();
-        if (this.permission != null && !this.permission.isEmpty()) {
-            permissions.addAll(Arrays.asList(ACFPatterns.COMMA.split(this.permission)));
-        }
-        if (parentCommand != null) {
-            permissions.addAll(parentCommand.getRequiredPermissions());
-        }
-
-        return permissions;
+        return this.permissions;
     }
 
     public boolean requiresPermission(String permission) {

--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -908,7 +908,7 @@ public abstract class BaseCommand {
     }
 
     public boolean hasPermission(CommandIssuer issuer) {
-        return permission == null || permission.isEmpty() || (manager.hasPermission(issuer, permission) && (parentCommand == null || parentCommand.hasPermission(issuer)));
+        return getRequiredPermissions().stream().allMatch(permission -> manager.hasPermission(issuer, permission)) && (parentCommand == null || parentCommand.hasPermission(issuer));
     }
 
     public Set<String> getRequiredPermissions() {


### PR DESCRIPTION
Currently the BaseCommand#hasPermission method doesn't actually check if the user has all the required permissions to execute a command, resulting in the following issue:

If user has permission permission.a they can execute:
/example
/example test
/example sub
/example sub testsub

Which is proper but if the user doesn't have permission.a they can only execute:
/example sub testsub

Example code:
```java
@CommandAlias("example")
@CommandPermission("permission.a")
public class ExampleCommand extends BaseCommand {

    @HelpCommand
    public void help(CommandHelp help) {
        help.showHelp();
    }

    @Subcommand("test")
    public void test(CommandSender sender) {
        sender.sendMessage("has permission to test?");
    }

    @Subcommand("sub")
    public class ExampleBCommand extends BaseCommand {

        @Subcommand("testsub")
        public void testSub(CommandSender sender) {
            sender.sendMessage("has permission to testSub?");
        }

    }

    @Subcommand("othersub")
    @CommandPermission("permission.b")
    public class ExampleCCommand extends BaseCommand {

        @Subcommand("othersub")
        public void otherSub(CommandSender sender) {
            sender.sendMessage("has permission to otherSub?");
        }

    }
}
```