### PR TITLE
Switched getField to getDeclaredField for the locale field in BukkitCommandManager

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -283,7 +283,7 @@ public class BukkitCommandManager extends CommandManager<
             }
             Object nmsPlayer = entityField.get(player);
             if (nmsPlayer != null) {
-                Field localeField = nmsPlayer.getClass().getField("locale");
+                Field localeField = nmsPlayer.getClass().getDeclaredField("locale");
                 Object localeString = localeField.get(nmsPlayer);
                 if (localeString instanceof String) {
                     String[] split = ACFPatterns.UNDERSCORE.split((String) localeString);


### PR DESCRIPTION
This resolves an issue where CraftBukkit has the locale field as private.