### PR TITLE
Added Method-Getter in RegisteredCommand class

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -34,6 +34,7 @@ import co.aikar.commands.annotation.Syntax;
 import co.aikar.commands.contexts.ContextResolver;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -328,7 +329,7 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
         this.registeredSubcommands.addAll(cmd);
     }
 
-    public Method getMethod() {
-        return method;
+    public <T extends Annotation> T getAnnotation(Class<T> annotation) {
+        return method.getAnnotation(annotation);
     }
 }

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -327,4 +327,8 @@ public class RegisteredCommand <CEC extends CommandExecutionContext<CEC, ? exten
     public void addSubcommands(Collection<String> cmd) {
         this.registeredSubcommands.addAll(cmd);
     }
+
+    public Method getMethod() {
+        return method;
+    }
 }


### PR DESCRIPTION
I want to use own annotations for help implementations (link, tooltips, short description etc.)
I can't access the method directly for the annotations, please add the getter ;)