### PR TITLE
Make InvalidCommandArgument a runtime exception

### DIFF
--- a/core/src/main/java/co/aikar/commands/InvalidCommandArgument.java
+++ b/core/src/main/java/co/aikar/commands/InvalidCommandArgument.java
@@ -26,7 +26,7 @@ package co.aikar.commands;
 import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
 
-public class InvalidCommandArgument extends Exception {
+public class InvalidCommandArgument extends RuntimeException {
     final boolean showSyntax;
     final MessageKey key;
     final String[] replacements;
@@ -34,18 +34,23 @@ public class InvalidCommandArgument extends Exception {
     public InvalidCommandArgument() {
         this(null, true);
     }
+
     public InvalidCommandArgument(boolean showSyntax) {
         this(null, showSyntax);
     }
+
     public InvalidCommandArgument(MessageKeyProvider key, String... replacements) {
         this(key.getMessageKey(), replacements);
     }
+
     public InvalidCommandArgument(MessageKey key, String... replacements) {
         this(key, true, replacements);
     }
+
     public InvalidCommandArgument(MessageKeyProvider key, boolean showSyntax, String... replacements) {
         this(key.getMessageKey(), showSyntax, replacements);
     }
+
     public InvalidCommandArgument(MessageKey key, boolean showSyntax, String... replacements) {
         super(key.getKey(), null, false, false);
         this.showSyntax = showSyntax;
@@ -54,7 +59,7 @@ public class InvalidCommandArgument extends Exception {
     }
 
     public InvalidCommandArgument(String message) {
-     this(message, true);
+        this(message, true);
     }
 
     public InvalidCommandArgument(String message, boolean showSyntax) {


### PR DESCRIPTION
The title says everything. Oh, and the spaces, intellij pasted them when I did Ctrl + K to commit