### PR TITLE
Declare dependency versions in parent POM

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>acf-core</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -47,13 +47,11 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>minecraft-timings</artifactId>
-            <version>1.0.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -35,7 +35,6 @@
     </parent>
 
     <artifactId>acf-bukkit</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (Bukkit)</name>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -23,7 +23,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>acf-core</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.12-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -10,7 +10,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>acf-bungee</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (Bungee)</name>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,6 @@
     </parent>
 
     <artifactId>acf-core</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (Core)</name>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,19 +42,16 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>Table</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>locales</artifactId>
-            <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
-            <version>0.5.8</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/jda/pom.xml
+++ b/jda/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>3.5.0_327</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jda/pom.xml
+++ b/jda/pom.xml
@@ -35,7 +35,6 @@
     </parent>
 
     <artifactId>acf-jda</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (JDA)</name>
 

--- a/jda/pom.xml
+++ b/jda/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/jda/pom.xml
+++ b/jda/pom.xml
@@ -48,7 +48,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>acf-core</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -35,7 +35,6 @@
     </parent>
 
     <artifactId>acf-paper</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (Paper)</name>
 

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>acf-bukkit</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-bukkit</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,61 @@
                 <artifactId>acf-jda</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>co.aikar</groupId>
+                <artifactId>minecraft-timings</artifactId>
+                <version>1.0.4</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.bukkit</groupId>
+                <artifactId>bukkit</artifactId>
+                <version>1.12-R0.1-SNAPSHOT</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.md-5</groupId>
+                <artifactId>bungeecord-api</artifactId>
+                <version>1.12-SNAPSHOT</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>co.aikar</groupId>
+                <artifactId>Table</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>co.aikar</groupId>
+                <artifactId>locales</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.jodah</groupId>
+                <artifactId>expiringmap</artifactId>
+                <version>0.5.8</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.dv8tion</groupId>
+                <artifactId>JDA</artifactId>
+                <version>3.5.0_327</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.destroystokyo.paper</groupId>
+                <artifactId>paper-api</artifactId>
+                <version>1.12.2-R0.1-SNAPSHOT</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.spongepowered</groupId>
+                <artifactId>spongeapi</artifactId>
+                <version>5.1.0</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+                    </dependencyReducedPomLocation>
                     <!-- when downloading via Maven we can pull depends individually -->
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                 </configuration>
@@ -128,6 +129,36 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-bukkit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-paper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-bungee</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-sponge</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>acf-jda</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -35,7 +35,6 @@
     </parent>
 
     <artifactId>acf-sponge</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
     <name>ACF (Sponge)</name>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -47,7 +47,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>acf-core</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>5.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR makes all dependencies be declared in parent POM instead of each submodule which makes it easier to keep them up-to-date for the whole project.
As a related feature, submodules are also declared in `dependencyManagement` and variables are used where possible so less stuff should be replaced manually.