### PR TITLE
Use getter for command conditions

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -145,7 +145,7 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
         }
         preCommand();
         try {
-            this.manager.conditions.validateConditions(context);
+            this.manager.getCommandConditions().validateConditions(context);
             Map<String, Object> passedArgs = resolveContexts(sender, args);
             if (passedArgs == null) return;
 
@@ -256,7 +256,7 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
                         throw new IllegalStateException("Parameter " + parameter.getName() + " is primitive and does not support Optional.");
                     }
                     //noinspection unchecked
-                    this.manager.conditions.validateConditions(context, value);
+                    this.manager.getCommandConditions().validateConditions(context, value);
                     passedArgs.put(parameterName, value);
                     continue;
                 } else if (requiresInput) {
@@ -296,7 +296,7 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
             Object paramValue = resolver.getContext(context);
 
             //noinspection unchecked
-            this.manager.conditions.validateConditions(context, paramValue);
+            this.manager.getCommandConditions().validateConditions(context, paramValue);
             passedArgs.put(parameterName, paramValue);
         }
         return passedArgs;


### PR DESCRIPTION
I created my own PaperCommandManager and want to share the completions, context resolver and conditions between multiple OwnCommandManagers. I have a static implementation which works fine except the command conditions.

Can we please change the command condition stuff here to use getters?

No breaking change and a nice thing for me.