### PR TITLE
Fix Bukkit log prefix for custom prefixes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ If you open a PR and are not already in this file, please feel free to add yours
 * [***Williambraecky***](https://github.com/aikar/commands/commits?author=Williambraecky) - BungeeCord Support
 * [***dumptruckman***](https://github.com/aikar/commands/commits?author=dumptruckman) - JDA Support
 * [***willies952002***](https://github.com/aikar/commands/commits?author=willies952002)
+* [***Machine_Maker***](https://github.com/aikar/commands/commits?author=Machine-Maker)

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -92,7 +92,7 @@ public class BukkitCommandManager extends CommandManager<
     @SuppressWarnings("JavaReflectionMemberAccess")
     public BukkitCommandManager(Plugin plugin) {
         this.plugin = plugin;
-        this.logger = Logger.getLogger(this.plugin.getName());
+        this.logger = Logger.getLogger(this.plugin.getDescription().getPrefix());
         this.timingManager = TimingManager.of(plugin);
         this.commandTiming = this.timingManager.of("Commands");
         this.commandMap = hookCommandMap();

--- a/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
+++ b/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
@@ -37,7 +37,8 @@ class PaperAsyncTabCompleteHandler implements Listener {
 
     PaperAsyncTabCompleteHandler(PaperCommandManager manager) {
         this.manager = manager;
-        manager.log(LogLevel.INFO, "Enabled Asynchronous Tab Completion Support!");
+        if (!Boolean.getBoolean("aikar.commands.disable-async-message"))
+            manager.log(LogLevel.INFO, "Enabled Asynchronous Tab Completion Support!");
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
+++ b/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
@@ -37,8 +37,7 @@ class PaperAsyncTabCompleteHandler implements Listener {
 
     PaperAsyncTabCompleteHandler(PaperCommandManager manager) {
         this.manager = manager;
-        if (!Boolean.getBoolean("aikar.commands.disable-async-message"))
-            manager.log(LogLevel.INFO, "Enabled Asynchronous Tab Completion Support!");
+        manager.log(LogLevel.INFO, "Enabled Asynchronous Tab Completion Support!");
     }
 
     @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
I was just working on a plugin when I realized that the Async support enabled message didn't have the same prefix that was in my plugin.yml. 