### PR TITLE
i18n,fr: fix garbled diacritics.

### DIFF
--- a/languages/core/acf-core_fr.properties
+++ b/languages/core/acf-core_fr.properties
@@ -20,27 +20,27 @@
 #  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 #  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-acf-core.permission_denied=Vous n'avez pas la permission d'ex�cuter cette commande.
-acf-core.error_generic_logged=Une erreur est survenue. Ce probl�me a �t� enregistr�. D�sol� pour le d�rangement.
+acf-core.permission_denied=Vous n'avez pas la permission d'exécuter cette commande.
+acf-core.error_generic_logged=Une erreur est survenue. Ce problème a été enregistré. Désolé pour le dérangement.
 acf-core.unknown_command=Commande inconnue, merci de faire <c2>/help</c2>
 acf-core.invalid_syntax=Usage: <c2>{command}</c2> <c3>{syntax}</c3>
 acf-core.error_prefix=Erreur: {message}
-acf-core.error_performing_command=Une erreur est survenue lors de l'ex�cution de cette commande.
+acf-core.error_performing_command=Une erreur est survenue lors de l'exécution de cette commande.
 acf-core.info_message={message}
 acf-core.please_specify_one_of=Erreur: Veuillez choisir parmi (<c2>{valid}</c2>).
-acf-core.must_be_a_number=Erreur: {num} doit �tre un nombre.
-acf-core.must_be_min_length=Erreur: Doit faire au moins {min} caract�res.
-acf-core.must_be_max_length=Erreur: Doit faire moins de {max} caract�res.
-acf-core.please_specify_at_most=Erreur: Veuillez sp�cifier une valeur inf�rieure � {max}
-acf-core.please_specify_at_least=Erreur: Veuillez sp�cifier une valeur sup�rieure � {min}
-acf-core.not_allowed_on_console=Erreur: La console ne peut pas ex�cuter cette commande.
+acf-core.must_be_a_number=Erreur: {num} doit être un nombre.
+acf-core.must_be_min_length=Erreur: Doit faire au moins {min} caractères.
+acf-core.must_be_max_length=Erreur: Doit faire moins de {max} caractères.
+acf-core.please_specify_at_most=Erreur: Veuillez spécifier une valeur inférieure à {max}
+acf-core.please_specify_at_least=Erreur: Veuillez spécifier une valeur supérieure à {min}
+acf-core.not_allowed_on_console=Erreur: La console ne peut pas exécuter cette commande.
 acf-core.could_not_find_player=Erreur: Impossible de trouver un joueur avec le nom: <c2>{search}</c2>
-acf-core.no_command_matched_search=Aucune commande correspondant � <c2>{search}</c2>.
-acf-core.help_page_information=- Page <c2>{page}</c2> de <c2>{totalpages}</c2> (<c3>{results}</c3> r�sultats).
-acf-core.help_no_results=Erreur: Plus aucun r�sultats.
+acf-core.no_command_matched_search=Aucune commande correspondant à <c2>{search}</c2>.
+acf-core.help_page_information=- Page <c2>{page}</c2> de <c2>{totalpages}</c2> (<c3>{results}</c3> résultats).
+acf-core.help_no_results=Erreur: Plus aucun résultat.
 acf-core.help_header=<c3>=== </c3><c1>Affichage de l'aide pour </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_format=<c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
-acf-core.help_detailed_header=<c3>=== </c3><c1>Affichage de l'aide d�taill�e pour </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
+acf-core.help_detailed_header=<c3>=== </c3><c1>Affichage de l'aide détaillée pour </c1><c2>{commandprefix}{command}</c2><c3> ===</c3>
 acf-core.help_detailed_command_format=<c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
 acf-core.help_detailed_parameter_format=<c2>{syntaxorname}</c2>: <c3>{description}</c3>
-acf-core.help_search_header=<c3>=== </c3><c1>R�sultats de la recherche pour </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>
+acf-core.help_search_header=<c3>=== </c3><c1>Résultats de la recherche pour </c1><c2>{commandprefix}{command} {search}</c2><c3> ===</c3>


### PR DESCRIPTION
I suspect e9857cb8 changed encoding for the file and messed up
diacritics.

Also fixed a slight typo on acf-core.help_no_results.