### PR TITLE
Console should be able to execute anything

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandIssuer.java
@@ -23,6 +23,7 @@
 
 package co.aikar.commands;
 
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -77,7 +78,7 @@ public class BukkitCommandIssuer implements CommandIssuer {
 
     @Override
     public boolean hasPermission(String name) {
-        return sender.hasPermission(name);
+        return sender instanceof ConsoleCommandSender || sender.hasPermission(name);
     }
 
     @Override


### PR DESCRIPTION
Under any circumstance, Console should have access to whichever permission ACF requires to execute some form for command.

If a command is executed as one would expect, the current outcome is that console does _not_ have permission to execute it, while a player might very well be able to.
![https://owo.whats-th.is/5MXNuuK.png](https://owo.whats-th.is/5MXNuuK.png)