### PR TITLE
Allow properly nesting of messages

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitLocales.java
@@ -24,7 +24,6 @@
 package co.aikar.commands;
 
 import co.aikar.locales.MessageKey;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -86,15 +85,12 @@ public class BukkitLocales extends Locales {
      */
     public boolean loadLanguage(FileConfiguration config, Locale locale) {
         boolean loaded = false;
-        for (String parentKey : config.getKeys(false)) {
-            ConfigurationSection inner = config.getConfigurationSection(parentKey);
-            if (inner == null) {
-                continue;
-            }
-            for (String key : inner.getKeys(false)) {
-                String value = inner.getString(key);
+        for (String key : config.getKeys(true)) {
+            if (config.isString(key) || config.isDouble(key) || config.isLong(key) || config.isInt(key)
+                    || config.isBoolean(key)) {
+                String value = config.getString(key);
                 if (value != null && !value.isEmpty()) {
-                    addMessage(locale, MessageKey.of(parentKey + "." + key), value);
+                    addMessage(locale, MessageKey.of(key), value);
                     loaded = true;
                 }
             }


### PR DESCRIPTION
- Messages can now be defined everywhere instead of second-level only
- The data types string, double, int, long and boolean are (still) supported

This pull request resolves #173. Other data types were supported before, but that is rarely useful I think, as having a `org.bukkit.Location` in your language file would result in an output like `Location{world=CraftWorld{name=world},x=-287.797836225297,y=70.5,z=-13.083220284478912,pitch=-29.70023,yaw=-90.7704}`.

If it's wanted to keep everything that isn't a ConfigurationSection, I'll go with it too and change that part.

Another improvement I could think of otherwise (or if  the string is null) would be to send a warn log message for invalid keys. What do you think about that?