### PR TITLE
Add name annotation for parameters

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -793,7 +793,7 @@ public abstract class BaseCommand {
     public void showSyntax(CommandIssuer issuer, RegisteredCommand<?> cmd) {
         issuer.sendMessage(MessageType.SYNTAX, MessageKeys.INVALID_SYNTAX,
                 "{command}", manager.getCommandPrefix(issuer) + cmd.command,
-                "{syntax}", cmd.syntaxText
+                "{syntax}", cmd.getSyntaxText(issuer)
         );
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandHelp.java
+++ b/core/src/main/java/co/aikar/commands/CommandHelp.java
@@ -107,7 +107,7 @@ public class CommandHelp {
             if (pattern.matcher(help.getDescription()).matches()) {
                 searchScore += 2;
             }
-            if (pattern.matcher(help.getParameterSyntax()).matches()) {
+            if (pattern.matcher(help.getParameterSyntax(issuer)).matches()) {
                 searchScore++;
             }
             if (help.getSearchTags() != null && pattern.matcher(help.getSearchTags()).matches()) {

--- a/core/src/main/java/co/aikar/commands/CommandHelpFormatter.java
+++ b/core/src/main/java/co/aikar/commands/CommandHelpFormatter.java
@@ -174,7 +174,7 @@ public class CommandHelpFormatter {
         return new String[]{
                 "{command}", entry.getCommand(),
                 "{commandprefix}", help.getCommandPrefix(),
-                "{parameters}", entry.getParameterSyntax(),
+                "{parameters}", entry.getParameterSyntax(help.getIssuer()),
                 "{separator}", entry.getDescription().isEmpty() ? "" : "-",
                 "{description}", entry.getDescription()
         };
@@ -192,9 +192,9 @@ public class CommandHelpFormatter {
     public String[] getParameterFormatReplacements(CommandHelp help, CommandParameter param, HelpEntry entry) {
         //{name} {description}
         return new String[]{
-                "{name}", param.getName(),
-                "{syntaxorname}", ACFUtil.nullDefault(param.getSyntax(), param.getName()),
-                "{syntax}", ACFUtil.nullDefault(param.getSyntax(), ""),
+                "{name}", param.getDisplayName(help.getIssuer()),
+                "{syntaxorname}", ACFUtil.nullDefault(param.getSyntax(help.getIssuer()), param.getDisplayName(help.getIssuer())),
+                "{syntax}", ACFUtil.nullDefault(param.getSyntax(help.getIssuer()), ""),
                 "{description}", ACFUtil.nullDefault(param.getDescription(), ""),
                 "{command}", help.getCommandName(),
                 "{fullcommand}", entry.getCommand(),

--- a/core/src/main/java/co/aikar/commands/CommandParameter.java
+++ b/core/src/main/java/co/aikar/commands/CommandParameter.java
@@ -171,7 +171,7 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
     }
 
     public String getDisplayName(CommandIssuer issuer) {
-        String translated = manager.getLocales().getOptionalMessage(issuer, MessageKey.of("acf.parameter." + name.toLowerCase()));
+        String translated = manager.getLocales().getOptionalMessage(issuer, MessageKey.of("acf-core.parameter." + name.toLowerCase()));
         return translated != null ? translated : name;
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandParameter.java
+++ b/core/src/main/java/co/aikar/commands/CommandParameter.java
@@ -28,6 +28,7 @@ import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Flags;
+import co.aikar.commands.annotation.Name;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Syntax;
@@ -36,6 +37,7 @@ import co.aikar.commands.contexts.ContextResolver;
 import co.aikar.commands.contexts.IssuerAwareContextResolver;
 import co.aikar.commands.contexts.IssuerOnlyContextResolver;
 import co.aikar.commands.contexts.OptionalContextResolver;
+import co.aikar.locales.MessageKey;
 
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
@@ -74,11 +76,12 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
         this.parameter = param;
         this.isLast = isLast;
         this.type = param.getType();
-        this.name = param.getName(); // do we care for an annotation to supply name?
         this.manager = command.manager;
         this.paramIndex = paramIndex;
         Annotations annotations = manager.getAnnotations();
 
+        String annotationName = annotations.getAnnotationValue(param, Name.class, Annotations.REPLACEMENTS);
+        this.name = annotationName != null ? annotationName : param.getName();
         this.defaultValue = annotations.getAnnotationValue(param, Default.class, Annotations.REPLACEMENTS | (type != String.class ? Annotations.NO_EMPTY : 0));
         this.description = annotations.getAnnotationValue(param, Description.class, Annotations.REPLACEMENTS | Annotations.DEFAULT_EMPTY);
         this.conditions = annotations.getAnnotationValue(param, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
@@ -107,13 +110,6 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
 
         if (!commandIssuer) {
             this.syntax = annotations.getAnnotationValue(param, Syntax.class);
-            if (syntax == null) {
-                if (isOptionalInput) {
-                    this.syntax = "[" + name + "]";
-                } else if (requiresInput) {
-                    this.syntax = "<" + name + ">";
-                }
-            }
         }
 
         this.flags = new HashMap<>();
@@ -172,6 +168,12 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
 
     public String getName() {
         return name;
+    }
+
+    public String getDisplayName(CommandIssuer issuer) {
+        if(issuer == null) return name;
+        String translated = manager.getLocales().getOptionalMessage(issuer, MessageKey.of("acf.parameter." + name.toLowerCase()));
+        return translated != null ? translated : name;
     }
 
     public CommandManager getManager() {
@@ -266,7 +268,15 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
         this.requiresInput = requiresInput;
     }
 
-    public String getSyntax() {
+    public String getSyntax(CommandIssuer issuer) {
+        if (commandIssuer) return null;
+        if (syntax == null) {
+            if (isOptionalInput) {
+                return "[" + getDisplayName(issuer) + "]";
+            } else if (requiresInput) {
+                return "<" + getDisplayName(issuer) + ">";
+            }
+        }
         return syntax;
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandParameter.java
+++ b/core/src/main/java/co/aikar/commands/CommandParameter.java
@@ -171,7 +171,6 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
     }
 
     public String getDisplayName(CommandIssuer issuer) {
-        if(issuer == null) return name;
         String translated = manager.getLocales().getOptionalMessage(issuer, MessageKey.of("acf.parameter." + name.toLowerCase()));
         return translated != null ? translated : name;
     }
@@ -266,6 +265,10 @@ public class CommandParameter<CEC extends CommandExecutionContext<CEC, ? extends
 
     public void setRequiresInput(boolean requiresInput) {
         this.requiresInput = requiresInput;
+    }
+
+    public String getSyntax() {
+        return getSyntax(null);
     }
 
     public String getSyntax(CommandIssuer issuer) {

--- a/core/src/main/java/co/aikar/commands/HelpEntry.java
+++ b/core/src/main/java/co/aikar/commands/HelpEntry.java
@@ -46,8 +46,13 @@ public class HelpEntry {
         return this.commandHelp.getCommandPrefix();
     }
 
-    public String getParameterSyntax(){
+    public String getParameterSyntax() {
         return this.command.syntaxText != null ? this.command.syntaxText : "";
+    }
+
+    public String getParameterSyntax(CommandIssuer issuer) {
+        String translated = this.command.getSyntaxText(issuer);
+        return translated != null ? translated : "";
     }
 
     public String getDescription(){

--- a/core/src/main/java/co/aikar/commands/HelpEntry.java
+++ b/core/src/main/java/co/aikar/commands/HelpEntry.java
@@ -47,7 +47,7 @@ public class HelpEntry {
     }
 
     public String getParameterSyntax() {
-        return this.command.syntaxText != null ? this.command.syntaxText : "";
+        return this.getParameterSyntax(null);
     }
 
     public String getParameterSyntax(CommandIssuer issuer) {

--- a/core/src/main/java/co/aikar/commands/Locales.java
+++ b/core/src/main/java/co/aikar/commands/Locales.java
@@ -181,6 +181,9 @@ public class Locales {
     }
 
     public String getOptionalMessage(CommandIssuer issuer, MessageKey key) {
+        if (issuer == null) {
+            return this.localeManager.getTable(getDefaultLocale()).getMessage(key);
+        }
         return this.localeManager.getMessage(issuer, key);
     }
 

--- a/core/src/main/java/co/aikar/commands/Locales.java
+++ b/core/src/main/java/co/aikar/commands/Locales.java
@@ -180,6 +180,10 @@ public class Locales {
         return message;
     }
 
+    public String getOptionalMessage(CommandIssuer issuer, MessageKey key) {
+        return this.localeManager.getMessage(issuer, key);
+    }
+
     public String replaceI18NStrings(String message) {
         if (message == null) {
             return null;

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -97,6 +97,7 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
         this.helpText = annotations.getAnnotationValue(method, Description.class, Annotations.REPLACEMENTS | Annotations.DEFAULT_EMPTY);
         this.conditions = annotations.getAnnotationValue(method, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
         this.helpSearchTags = annotations.getAnnotationValue(method, HelpSearchTags.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.syntaxText = annotations.getAnnotationValue(method, Syntax.class, Annotations.REPLACEMENTS);
 
         Parameter[] parameters = method.getParameters();
         //noinspection unchecked
@@ -108,7 +109,6 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
         int consumeInputResolvers = 0;
         int doesNotConsumeInputResolvers = 0;
         int optionalResolvers = 0;
-        StringBuilder syntaxBuilder = new StringBuilder(64);
 
         CommandParameter<CEC> previousParam = null;
         for (int i = 0; i < parameters.length; i++) {
@@ -129,16 +129,8 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
                     doesNotConsumeInputResolvers++;
                 }
             }
-            if (parameter.getSyntax() != null) {
-                if (syntaxBuilder.length() > 0) {
-                    syntaxBuilder.append(' ');
-                }
-                syntaxBuilder.append(parameter.getSyntax());
-            }
         }
-        String syntaxText = syntaxBuilder.toString().trim();
-        final String syntaxStr = annotations.getAnnotationValue(method, Syntax.class);
-        this.syntaxText = syntaxStr != null ? ACFUtil.replace(syntaxStr, "@syntax", syntaxText) : syntaxText;
+
         this.requiredResolvers = requiredResolvers;
         this.consumeInputResolvers = consumeInputResolvers;
         this.doesNotConsumeInputResolvers = doesNotConsumeInputResolvers;
@@ -345,7 +337,21 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
     }
 
     public String getSyntaxText() {
-        return syntaxText;
+        return getSyntaxText(null);
+    }
+
+    public String getSyntaxText(CommandIssuer issuer) {
+        if (syntaxText != null) return syntaxText;
+        StringBuilder syntaxBuilder = new StringBuilder(64);
+        for (CommandParameter<?> parameter : parameters) {
+            if (parameter.getSyntax(null) != null) {
+                if (syntaxBuilder.length() > 0) {
+                    syntaxBuilder.append(' ');
+                }
+                syntaxBuilder.append(parameter.getSyntax(issuer));
+            }
+        }
+        return syntaxBuilder.toString().trim();
     }
 
     public String getHelpText() {

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -344,11 +344,12 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
         if (syntaxText != null) return syntaxText;
         StringBuilder syntaxBuilder = new StringBuilder(64);
         for (CommandParameter<?> parameter : parameters) {
-            if (parameter.getSyntax(null) != null) {
+            String syntax = parameter.getSyntax(issuer);
+            if (syntax != null) {
                 if (syntaxBuilder.length() > 0) {
                     syntaxBuilder.append(' ');
                 }
-                syntaxBuilder.append(parameter.getSyntax(issuer));
+                syntaxBuilder.append(syntax);
             }
         }
         return syntaxBuilder.toString().trim();

--- a/core/src/main/java/co/aikar/commands/annotation/Name.java
+++ b/core/src/main/java/co/aikar/commands/annotation/Name.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-2020 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface Name {
+    String value();
+}


### PR DESCRIPTION
I added a name annotation to change the display name from a parameter.

Either you can use the name annotation directly:
```java
@Subcommand("test")
public class TestCmd extends BaseCommand {
    @Default
    public void onTest(Player executor,
                       @Name("Text")String word,
                       @Name("Anzahl")int amount) {
        executor.sendMessage("Word: \"" + word + "\" and amount " + amount);
    }
}
```

Or you can modify the name by adding the message key to the locale:
```java
manager.getLocales().addMessageStrings(manager.getLocales().getDefaultLocale(), 
                Collections.singletonMap("acf.parameter.text", "Banane"));
```

With @Name annotation the names will be changed:
![grafik](https://user-images.githubusercontent.com/15250323/80720409-23311680-8afd-11ea-91af-e881e3413a82.png)

It should not affect backwards compatibility

I failed some git-branch things in https://github.com/aikar/commands/pull/263
Now I'm unable to reopen the old pull request, shame on me.