### PR TITLE
Fix wrong BungeeCord command suggestions

### DIFF
--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
@@ -90,7 +90,7 @@ public class BungeeRootCommand extends Command implements RootCommand, TabExecut
 
     @Override
     public boolean hasPermission(CommandSender sender) {
-        return uniquePermission == null || uniquePermission.isEmpty() || sender.hasPermission(uniquePermission);
+        return hasAnyPermission(manager.getCommandIssuer(sender));
     }
 
     @Override

--- a/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeRootCommand.java
@@ -89,6 +89,11 @@ public class BungeeRootCommand extends Command implements RootCommand, TabExecut
     }
 
     @Override
+    public boolean hasPermission(CommandSender sender) {
+        return uniquePermission == null || uniquePermission.isEmpty() || sender.hasPermission(uniquePermission);
+    }
+
+    @Override
     public Iterable<String> onTabComplete(CommandSender commandSender, String[] strings) {
         return getTabCompletions(manager.getCommandIssuer(commandSender), getName(), strings);
     }


### PR DESCRIPTION
https://github.com/SpigotMC/BungeeCord/commit/a47b8033857973588a0da98d3ebdc5d970176fa9

This commit added some magic stuff to BungeeCord to check permissions for commands.
ACF already overrides the getPermission method but hasPermission method is untouched.

I had to increase the BungeeCord-Api version to 1.13 but that should be no problem since BungeeCord is backwards compatible to 1.8.