### PR TITLE
Add option to use bot mention as prefix

### DIFF
--- a/jda/src/main/java/co/aikar/commands/CommandConfig.java
+++ b/jda/src/main/java/co/aikar/commands/CommandConfig.java
@@ -8,6 +8,10 @@ import java.util.List;
 public interface CommandConfig extends CommandConfigProvider {
     @NotNull List<String> getCommandPrefixes();
 
+    default boolean mentionPrefixEnabled() {
+        return false;
+    }
+
     @Override
     default CommandConfig provide(MessageReceivedEvent event) {
         return this;

--- a/jda/src/main/java/co/aikar/commands/JDACommandConfig.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandConfig.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class JDACommandConfig implements CommandConfig {
     protected @NotNull List<String> commandPrefixes = new CopyOnWriteArrayList<>(new String[]{"!"});
+    protected boolean useMentionPrefix = false;
 
     public JDACommandConfig() {
 
@@ -15,5 +16,14 @@ public class JDACommandConfig implements CommandConfig {
     @NotNull
     public List<String> getCommandPrefixes() {
         return commandPrefixes;
+    }
+
+    public void useMentionPrefix(boolean useMentionPrefix) {
+        this.useMentionPrefix = useMentionPrefix;
+    }
+
+    @Override
+    public boolean mentionPrefixEnabled() {
+        return this.useMentionPrefix;
     }
 }

--- a/jda/src/main/java/co/aikar/commands/JDACommandManager.java
+++ b/jda/src/main/java/co/aikar/commands/JDACommandManager.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -237,6 +238,7 @@ public class JDACommandManager extends CommandManager<
     void dispatchEvent(MessageReceivedEvent event) {
         Message message = event.getMessage();
         String msg = message.getContentRaw();
+        String selfUserId = event.getJDA().getSelfUser().getId();
 
         CommandConfig config = getCommandConfig(event);
 
@@ -247,11 +249,19 @@ public class JDACommandManager extends CommandManager<
                 break;
             }
         }
+        if (prefixFound == null && config.mentionPrefixEnabled()) {
+            if (msg.startsWith("<@" + selfUserId + ">")) {
+                prefixFound = "<@" + selfUserId + ">";
+            } else if (msg.startsWith("<@!" + selfUserId + ">")) {
+                prefixFound = "<@!" + selfUserId + ">";
+            }
+        }
         if (prefixFound == null) {
             return;
         }
 
-        String[] args = ACFPatterns.SPACE.split(msg.substring(prefixFound.length()), -1);
+        // str.replaceAll("^[ \t]+", "") - works like String.stripLeading() from Java 11
+        String[] args = ACFPatterns.SPACE.split(msg.substring(prefixFound.length()).replaceAll("^[ \\t]+", ""), -1);
         if (args.length == 0) {
             return;
         }


### PR DESCRIPTION
I added an option to use bot mention as a command prefix. Might be useful when you have per-server prefixes and forget what prefix is used in a particular server. You can enable it with this code:
```java
JDACommandConfig config = new JDACommandConfig();
config.useMentionPrefix(true);
```

It's disabled by default, so it won't change any behaviour until you turn it on