### PR TITLE
Add Adventure/MiniMessage as new message parser to acf

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,18 +10,22 @@
         <module name="acf-sponge" />
         <module name="acf" />
         <module name="acf-example" />
-        <module name="example-plugin" />
         <module name="acf-brigadier" />
         <module name="acf-paper" />
         <module name="acf-jda" />
-        <module name="acf-core" />
-        <module name="acf-velocity" />
-        <module name="acf-bukkit" />
         <module name="acf-bungee" />
+        <module name="acf-adventure-bukkit" />
+        <module name="acf-bukkit" />
+        <module name="acf-velocity" />
+        <module name="acf-adventure-bungee" />
+        <module name="acf-core" />
+        <module name="example-plugin" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="acf" target="1.8" />
+      <module name="acf-adventure-bukkit" target="1.8" />
+      <module name="acf-adventure-bungee" target="1.8" />
       <module name="acf-brigadier" target="1.8" />
       <module name="acf-bukkit" target="1.8" />
       <module name="acf-bungee" target="1.8" />
@@ -38,6 +42,8 @@
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="acf-adventure-bukkit" options="-parameters" />
+      <module name="acf-adventure-bungee" options="-parameters" />
       <module name="acf-brigadier" options="-parameters" />
       <module name="acf-bukkit" options="-parameters" />
       <module name="acf-bungee" options="-parameters" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,6 +2,8 @@
 <project version="4">
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/adventure/bukkit/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/adventure/bungee/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/brigadier" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/brigadier/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/bukkit" charset="UTF-8" />

--- a/adventure/bukkit/pom.xml
+++ b/adventure/bukkit/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/adventure/bukkit/pom.xml
+++ b/adventure/bukkit/pom.xml
@@ -31,26 +31,20 @@
         <groupId>co.aikar</groupId>
         <artifactId>acf-parent</artifactId>
         <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>acf-bukkit</artifactId>
+    <artifactId>acf-adventure-bukkit</artifactId>
     <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
-    <name>ACF (Bukkit)</name>
+    <name>ACF Adventure (Bukkit)</name>
 
     <dependencies>
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
             <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>co.aikar</groupId>
-            <artifactId>minecraft-timings</artifactId>
-            <version>1.0.4</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
@@ -59,17 +53,22 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>co.aikar</groupId>
-            <artifactId>acf-adventure-bukkit</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.3.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <build>
-        <resources>
-            <resource>
-                <directory>${project.basedir}/../languages/minecraft/</directory>
-            </resource>
-        </resources>
-    </build>
 </project>

--- a/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
+++ b/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
@@ -8,6 +8,7 @@ import org.bukkit.plugin.Plugin;
 
 public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
     private BukkitAudiences audiences;
+    private MiniMessage miniMessage;
 
     public ACFBukkitAdventureManager(Plugin plugin, CommandManager<?, ?, ? extends ChatColor, ?, ?, ?> manager) {
         super(manager);
@@ -15,7 +16,15 @@ public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
         this.audiences = BukkitAudiences.create(plugin);
     }
 
-    public Audience wrapIssuer(CommandIssuer issuer) {
+    public MiniMessage getMiniMessage() {
+        return miniMessage;
+    }
+
+    public void setMiniMessage(MiniMessage miniMessage) {
+        this.miniMessage = miniMessage;
+    }
+
+    private Audience wrapIssuer(CommandIssuer issuer) {
         return this.audiences.sender(issuer.getIssuer());
     }
 
@@ -29,8 +38,7 @@ public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
                 message = message.replace("</c" + i + ">", "</color:" + colorname + ">");
             }
         }
-        wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
-        manager.log(LogLevel.INFO, message);
+        wrapIssuer(issuer).sendMessage(miniMessage.parse(message));
     }
 }
 

--- a/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
+++ b/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
@@ -14,6 +14,7 @@ public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
         super(manager);
 
         this.audiences = BukkitAudiences.create(plugin);
+        this.miniMessage = MiniMessage.get();
 
         CommandContexts<? extends CommandExecutionContext<?, ? extends CommandIssuer>> contexts = manager.getCommandContexts();
         contexts.registerIssuerOnlyContext(Audience.class, c -> wrapIssuer(c.getIssuer()));

--- a/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
+++ b/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
@@ -14,6 +14,9 @@ public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
         super(manager);
 
         this.audiences = BukkitAudiences.create(plugin);
+
+        CommandContexts<? extends CommandExecutionContext<?, ? extends CommandIssuer>> contexts = manager.getCommandContexts();
+        contexts.registerIssuerOnlyContext(Audience.class, c -> wrapIssuer(c.getIssuer()));
     }
 
     public MiniMessage getMiniMessage() {

--- a/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
+++ b/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
@@ -1,0 +1,26 @@
+package co.aikar.commands;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.plugin.Plugin;
+
+public class ACFBukkitAdventureManager extends ACFAdventureManager {
+    private BukkitAudiences audiences;
+
+    public ACFBukkitAdventureManager(Plugin plugin, CommandManager<?, ?, ?, ?, ?, ?> manager) {
+        super(manager);
+
+        this.audiences = BukkitAudiences.create(plugin);
+    }
+
+    public Audience wrapIssuer(CommandIssuer issuer) {
+        return this.audiences.sender(issuer.getIssuer());
+    }
+
+    @Override
+    public void sendMessage(CommandIssuer issuer, String message) {
+        wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
+    }
+}
+

--- a/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
+++ b/adventure/bukkit/src/main/java/co.aikar.commands/ACFBukkitAdventureManager.java
@@ -3,12 +3,13 @@ package co.aikar.commands;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 
-public class ACFBukkitAdventureManager extends ACFAdventureManager {
+public class ACFBukkitAdventureManager extends ACFAdventureManager<ChatColor> {
     private BukkitAudiences audiences;
 
-    public ACFBukkitAdventureManager(Plugin plugin, CommandManager<?, ?, ?, ?, ?, ?> manager) {
+    public ACFBukkitAdventureManager(Plugin plugin, CommandManager<?, ?, ? extends ChatColor, ?, ?, ?> manager) {
         super(manager);
 
         this.audiences = BukkitAudiences.create(plugin);
@@ -19,8 +20,17 @@ public class ACFBukkitAdventureManager extends ACFAdventureManager {
     }
 
     @Override
-    public void sendMessage(CommandIssuer issuer, String message) {
+    public void sendMessage(CommandIssuer issuer, MessageFormatter<ChatColor> formatter, String message) {
+        if (formatter != null) {
+            message = "<color:" + formatter.getDefaultColor().name().toLowerCase() + ">" + message;
+            for (int i = 1; i <= formatter.getColors().size(); ++i) {
+                String colorname = formatter.getColor(i).name().toLowerCase();
+                message = message.replace("<c" + i + ">", "<color:" + colorname + ">");
+                message = message.replace("</c" + i + ">", "</color:" + colorname + ">");
+            }
+        }
         wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
+        manager.log(LogLevel.INFO, message);
     }
 }
 

--- a/adventure/bungee/pom.xml
+++ b/adventure/bungee/pom.xml
@@ -31,45 +31,44 @@
         <groupId>co.aikar</groupId>
         <artifactId>acf-parent</artifactId>
         <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>acf-bukkit</artifactId>
+    <artifactId>acf-adventure-bungee</artifactId>
     <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
 
-    <name>ACF (Bukkit)</name>
+    <name>ACF Adventure (Bungee)</name>
 
     <dependencies>
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-core</artifactId>
             <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>co.aikar</groupId>
-            <artifactId>minecraft-timings</artifactId>
-            <version>1.0.4</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>co.aikar</groupId>
-            <artifactId>acf-adventure-bukkit</artifactId>
-            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <version>1.13-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.3.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bungeecord</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <build>
-        <resources>
-            <resource>
-                <directory>${project.basedir}/../languages/minecraft/</directory>
-            </resource>
-        </resources>
-    </build>
 </project>

--- a/adventure/bungee/pom.xml
+++ b/adventure/bungee/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.13-SNAPSHOT</version>
+            <version>1.16-R0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/adventure/bungee/pom.xml
+++ b/adventure/bungee/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -14,6 +14,7 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
         super(manager);
 
         this.audiences = BungeeAudiences.create(plugin);
+        this.miniMessage = MiniMessage.get();
 
         CommandContexts<? extends CommandExecutionContext<?, ? extends CommandIssuer>> contexts = manager.getCommandContexts();
         contexts.registerIssuerOnlyContext(Audience.class, c -> wrapIssuer(c.getIssuer()));

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 
 public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
     private BungeeAudiences audiences;
+    private MiniMessage miniMessage;
 
     public ACFBungeeAdventureManager(Plugin plugin, CommandManager<?, ?, ? extends ChatColor, ?, ?, ?> manager) {
         super(manager);
@@ -15,7 +16,15 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
         this.audiences = BungeeAudiences.create(plugin);
     }
 
-    public Audience wrapIssuer(CommandIssuer issuer) {
+    public MiniMessage getMiniMessage() {
+        return miniMessage;
+    }
+
+    public void setMiniMessage(MiniMessage miniMessage) {
+        this.miniMessage = miniMessage;
+    }
+
+    private Audience wrapIssuer(CommandIssuer issuer) {
         return this.audiences.sender(issuer.getIssuer());
     }
 
@@ -29,7 +38,7 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
                 message = message.replace("</c" + i + ">", "</color:" + colorname + ">");
             }
         }
-        wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
+        wrapIssuer(issuer).sendMessage(miniMessage.parse(message));
     }
 }
 

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -14,6 +14,9 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
         super(manager);
 
         this.audiences = BungeeAudiences.create(plugin);
+
+        CommandContexts<? extends CommandExecutionContext<?, ? extends CommandIssuer>> contexts = manager.getCommandContexts();
+        contexts.registerIssuerOnlyContext(Audience.class, c -> wrapIssuer(c.getIssuer()));
     }
 
     public MiniMessage getMiniMessage() {

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -22,7 +22,7 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
     @Override
     public void sendMessage(CommandIssuer issuer, MessageFormatter<ChatColor> formatter, String message) {
         if (formatter != null) {
-            message = "<color:" + Integer.toHexString(formatter.getDefaultColor().getColor().getRGB()).substring(2) + ">" + message;
+            message = "<color:#" + Integer.toHexString(formatter.getDefaultColor().getColor().getRGB()).substring(2) + ">" + message;
             for (int i = 1; i <= formatter.getColors().size(); ++i) {
                 String colorname = "#" + Integer.toHexString(formatter.getColor(i).getColor().getRGB()).substring(2);
                 message = message.replace("<c" + i + ">", "<color:" + colorname + ">");

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -3,12 +3,13 @@ package co.aikar.commands;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.plugin.Plugin;
 
-public class ACFBungeeAdventureManager extends ACFAdventureManager {
+public class ACFBungeeAdventureManager extends ACFAdventureManager<ChatColor> {
     private BungeeAudiences audiences;
 
-    public ACFBungeeAdventureManager(Plugin plugin, CommandManager<?, ?, ?, ?, ?, ?> manager) {
+    public ACFBungeeAdventureManager(Plugin plugin, CommandManager<?, ?, ? extends ChatColor, ?, ?, ?> manager) {
         super(manager);
 
         this.audiences = BungeeAudiences.create(plugin);
@@ -19,7 +20,15 @@ public class ACFBungeeAdventureManager extends ACFAdventureManager {
     }
 
     @Override
-    public void sendMessage(CommandIssuer issuer, String message) {
+    public void sendMessage(CommandIssuer issuer, MessageFormatter<ChatColor> formatter, String message) {
+        if (formatter != null) {
+            message = "<color:" + Integer.toHexString(formatter.getDefaultColor().getColor().getRGB()).substring(2) + ">" + message;
+            for (int i = 1; i <= formatter.getColors().size(); ++i) {
+                String colorname = "#" + Integer.toHexString(formatter.getColor(i).getColor().getRGB()).substring(2);
+                message = message.replace("<c" + i + ">", "<color:" + colorname + ">");
+                message = message.replace("</c" + i + ">", "</color:" + colorname + ">");
+            }
+        }
         wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
     }
 }

--- a/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
+++ b/adventure/bungee/src/main/java/co.aikar.commands/ACFBungeeAdventureManager.java
@@ -1,0 +1,26 @@
+package co.aikar.commands;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.md_5.bungee.api.plugin.Plugin;
+
+public class ACFBungeeAdventureManager extends ACFAdventureManager {
+    private BungeeAudiences audiences;
+
+    public ACFBungeeAdventureManager(Plugin plugin, CommandManager<?, ?, ?, ?, ?, ?> manager) {
+        super(manager);
+
+        this.audiences = BungeeAudiences.create(plugin);
+    }
+
+    public Audience wrapIssuer(CommandIssuer issuer) {
+        return this.audiences.sender(issuer.getIssuer());
+    }
+
+    @Override
+    public void sendMessage(CommandIssuer issuer, String message) {
+        wrapIssuer(issuer).sendMessage(MiniMessage.get().parse(message));
+    }
+}
+

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -58,6 +58,11 @@
             <version>1.12-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -115,7 +115,7 @@ public class BukkitCommandManager extends CommandManager<
         }
 
         try {
-            Class.forName("co.aikar.commands.adventure.text.Component");
+            Class.forName("co.aikar.commands.adventure.adventure.text.Component");
             adventureAvailable = true;
         } catch (ClassNotFoundException ignored) {
             // Ignored
@@ -417,11 +417,13 @@ public class BukkitCommandManager extends CommandManager<
 
     @Override
     public void enableUnstableAPI(String api) {
+        super.enableUnstableAPI(api);
+
         if ("adventure".equals(api) && adventureAvailable) {
+            log(LogLevel.INFO, "Enabling Adventure");
             adventureManager = new ACFBukkitAdventureManager(plugin, this);
             super.adventureManager = adventureManager;
         }
-        super.enableUnstableAPI(api);
     }
 
     public @Nullable ACFBukkitAdventureManager getAdventureManager() {

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -46,6 +46,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -88,6 +89,8 @@ public class BukkitCommandManager extends CommandManager<
     protected BukkitLocales locales;
     private boolean cantReadLocale = false;
     protected boolean autoDetectFromClient = true;
+    private boolean adventureAvailable = false;
+    private ACFBukkitAdventureManager adventureManager;
 
     @SuppressWarnings("JavaReflectionMemberAccess")
     public BukkitCommandManager(Plugin plugin) {
@@ -110,6 +113,14 @@ public class BukkitCommandManager extends CommandManager<
             this.mcMinorVersion = -1;
             this.mcPatchVersion = -1;
         }
+
+        try {
+            Class.forName("co.aikar.commands.adventure.text.Component");
+            adventureAvailable = true;
+        } catch (ClassNotFoundException ignored) {
+            // Ignored
+        }
+
         Bukkit.getHelpMap().registerHelpTopicFactory(BukkitRootCommand.class, command -> {
             if (hasUnstableAPI("help")) {
                 return new ACFBukkitHelpTopic(this, (BukkitRootCommand) command);
@@ -402,5 +413,18 @@ public class BukkitCommandManager extends CommandManager<
             t = t.getCause();
         }
         return super.handleUncaughtException(scope, registeredCommand, sender, args, t);
+    }
+
+    @Override
+    public void enableUnstableAPI(String api) {
+        if ("adventure".equals(api) && adventureAvailable) {
+            adventureManager = new ACFBukkitAdventureManager(plugin, this);
+            super.adventureManager = adventureManager;
+        }
+        super.enableUnstableAPI(api);
+    }
+
+    public @Nullable ACFBukkitAdventureManager getAdventureManager() {
+        return adventureManager;
     }
 }

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -420,7 +420,6 @@ public class BukkitCommandManager extends CommandManager<
         super.enableUnstableAPI(api);
 
         if ("adventure".equals(api) && adventureAvailable) {
-            log(LogLevel.INFO, "Enabling Adventure");
             adventureManager = new ACFBukkitAdventureManager(plugin, this);
             super.adventureManager = adventureManager;
         }

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -35,6 +35,11 @@
             <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bungeecord</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -30,15 +30,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>co.aikar</groupId>
+            <artifactId>acf-adventure-bungee</artifactId>
+            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
             <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-platform-bungeecord</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -56,12 +56,22 @@ public class BungeeCommandManager extends CommandManager<
     protected BungeeCommandCompletions completions;
     protected BungeeLocales locales;
 
+    private boolean adventureAvailable = false;
+    private ACFBungeeAdventureManager adventureManager;
+
     public BungeeCommandManager(Plugin plugin) {
         this.plugin = plugin;
         this.formatters.put(MessageType.ERROR, defaultFormatter = new BungeeMessageFormatter(ChatColor.RED, ChatColor.YELLOW, ChatColor.RED));
         this.formatters.put(MessageType.SYNTAX, new BungeeMessageFormatter(ChatColor.YELLOW, ChatColor.GREEN, ChatColor.WHITE));
         this.formatters.put(MessageType.INFO, new BungeeMessageFormatter(ChatColor.BLUE, ChatColor.DARK_GREEN, ChatColor.GREEN));
         this.formatters.put(MessageType.HELP, new BungeeMessageFormatter(ChatColor.AQUA, ChatColor.GREEN, ChatColor.YELLOW));
+
+        try {
+            Class.forName("co.aikar.commands.adventure.text.Component");
+            adventureAvailable = true;
+        } catch (ClassNotFoundException ignored) {
+            // Ignored
+        }
 
         getLocales(); // auto load locales
 
@@ -219,5 +229,18 @@ public class BungeeCommandManager extends CommandManager<
     @Override
     public String getCommandPrefix(CommandIssuer issuer) {
         return issuer.isPlayer() ? "/" : "";
+    }
+
+    @Override
+    public void enableUnstableAPI(String api) {
+        if ("adventure".equals(api) && adventureAvailable) {
+            adventureManager = new ACFBungeeAdventureManager(plugin, this);
+            super.adventureManager = adventureManager;
+        }
+        super.enableUnstableAPI(api);
+    }
+
+    public ACFBungeeAdventureManager getAdventureManager() {
+        return adventureManager;
     }
 }

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -67,7 +67,7 @@ public class BungeeCommandManager extends CommandManager<
         this.formatters.put(MessageType.HELP, new BungeeMessageFormatter(ChatColor.AQUA, ChatColor.GREEN, ChatColor.YELLOW));
 
         try {
-            Class.forName("co.aikar.commands.adventure.text.Component");
+            Class.forName("co.aikar.commands.adventure.adventure.text.Component");
             adventureAvailable = true;
         } catch (ClassNotFoundException ignored) {
             // Ignored
@@ -233,11 +233,12 @@ public class BungeeCommandManager extends CommandManager<
 
     @Override
     public void enableUnstableAPI(String api) {
+        super.enableUnstableAPI(api);
+
         if ("adventure".equals(api) && adventureAvailable) {
             adventureManager = new ACFBungeeAdventureManager(plugin, this);
             super.adventureManager = adventureManager;
         }
-        super.enableUnstableAPI(api);
     }
 
     public ACFBungeeAdventureManager getAdventureManager() {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,18 +53,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-api</artifactId>
-            <version>4.3.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
             <version>0.5.9</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,18 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.3.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
             <version>0.5.9</version>

--- a/core/src/main/java/co/aikar/commands/ACFAdventureManager.java
+++ b/core/src/main/java/co/aikar/commands/ACFAdventureManager.java
@@ -23,14 +23,14 @@
 
 package co.aikar.commands;
 
-public abstract class ACFAdventureManager {
-    protected final CommandManager<?, ?, ?, ?, ?, ?> manager;
+public abstract class ACFAdventureManager<C> {
+    protected final CommandManager<?, ?, ? extends C, ?, ?, ?> manager;
 
-    public ACFAdventureManager(CommandManager<?, ? , ?, ?, ?, ?> manager) {
+    public ACFAdventureManager(CommandManager<?, ?, ? extends C, ?, ?, ?> manager) {
         manager.verifyUnstableAPI("adventure");
 
         this.manager = manager;
     }
 
-    public abstract void sendMessage(CommandIssuer issuer, String message);
+    public abstract void sendMessage(CommandIssuer issuer, MessageFormatter<C> formatter, String message);
 }

--- a/core/src/main/java/co/aikar/commands/ACFAdventureManager.java
+++ b/core/src/main/java/co/aikar/commands/ACFAdventureManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2020 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands;
+
+public abstract class ACFAdventureManager {
+    protected final CommandManager<?, ?, ?, ?, ?, ?> manager;
+
+    public ACFAdventureManager(CommandManager<?, ? , ?, ?, ?, ?> manager) {
+        manager.verifyUnstableAPI("adventure");
+
+        this.manager = manager;
+    }
+
+    public abstract void sendMessage(CommandIssuer issuer, String message);
+}

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -401,7 +401,8 @@ public abstract class CommandManager<
             // TODO: Use MessageType to format messages?
             String message = getAndReplaceMessage(issuer, key, replacements);
             for (String msg : ACFPatterns.NEWLINE.split(message)) {
-                adventureManager.sendMessage(issuer, msg);
+                MF formatter = formatters.getOrDefault(type, defaultFormatter);
+                adventureManager.sendMessage(issuer, formatter, msg);
             }
         } else {
             String message = formatMessage(issuer, type, key, replacements);

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -70,7 +70,7 @@ public abstract class CommandManager<
     protected final CommandReplacements replacements = new CommandReplacements(this);
     protected final CommandConditions<I, CEC, CC> conditions = new CommandConditions<>(this);
     protected ExceptionHandler defaultExceptionHandler = null;
-    protected ACFAdventureManager adventureManager;
+    protected ACFAdventureManager<FT> adventureManager;
     boolean logUnhandledExceptions = true;
     protected Table<Class<?>, String, Object> dependencies = new Table<>();
     protected CommandHelpFormatter helpFormatter = new CommandHelpFormatter(this);
@@ -398,7 +398,6 @@ public abstract class CommandManager<
 
     public void sendMessage(CommandIssuer issuer, MessageType type, MessageKeyProvider key, String... replacements) {
         if (hasUnstableAPI("adventure") && adventureManager != null) {
-            // TODO: Use MessageType to format messages?
             String message = getAndReplaceMessage(issuer, key, replacements);
             for (String msg : ACFPatterns.NEWLINE.split(message)) {
                 MF formatter = formatters.getOrDefault(type, defaultFormatter);

--- a/core/src/main/java/co/aikar/commands/MessageFormatter.java
+++ b/core/src/main/java/co/aikar/commands/MessageFormatter.java
@@ -95,4 +95,8 @@ public abstract class MessageFormatter <FT> {
         matcher.appendTail(sb);
         return def + sb.toString();
     }
+
+    public List<FT> getColors() {
+        return colors;
+    }
 }

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -120,5 +120,11 @@
             <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>co.aikar</groupId>
+            <artifactId>acf-adventure-bukkit</artifactId>
+            <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/example/src/main/java/co/aikar/acfexample/ACFExample.java
+++ b/example/src/main/java/co/aikar/acfexample/ACFExample.java
@@ -53,6 +53,9 @@ public final class ACFExample extends JavaPlugin {
         // optional: enable unstable api to use help
         commandManager.enableUnstableAPI("help");
 
+        // optional: enable minimessage parser
+        commandManager.enableUnstableAPI("adventure");
+
         // 2: Setup some replacement values that may be used inside of the annotations dynamically.
         commandManager.getCommandReplacements().addReplacements(
                 // key - value

--- a/example/src/main/java/co/aikar/acfexample/SomeCommand.java
+++ b/example/src/main/java/co/aikar/acfexample/SomeCommand.java
@@ -24,6 +24,7 @@
 package co.aikar.acfexample;
 
 import co.aikar.commands.BaseCommand;
+import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -130,6 +131,15 @@ public class SomeCommand extends BaseCommand {
     @CommandCompletion("* * @test foo1|foo2|foo3")
     public void onTestCompletion(CommandSender sender, OnlinePlayer player, World world, String test, String foo1, TestEnum e) {
         sender.sendMessage("You got " + player.getPlayer().getName() + " - " + world.getName() + " - " + test + " - " + foo1 + " - " + e.name());
+    }
+
+    @Subcommand("adventure")
+    @CommandAlias("clickable")
+    @Description("Test adventure with clickable text")
+    public void onTestAdventure(CommandIssuer issuer) {
+        issuer.sendMessage("<red>This is a <yellow>" +
+                "<hover:show_text:'<yellow>Click here'>" +
+                "<click:open_url:'https://docs.adventure.kyori.net/minimessage.html'>clickable message</click></hover></yellow>.");
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <id>aikar</id>
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
+        <repository>
+            <id>sonatype-oss</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,18 @@
                             <pattern>co.aikar.timings.lib</pattern>
                             <shadedPattern>co.aikar.commands.lib.timings</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>net.kyori.adventure</pattern>
+                            <shadedPattern>co.aikar.commands.adventure.adventure</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.kyori.examination</pattern>
+                            <shadedPattern>co.aikar.commands.adventure.examination</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.checkerframework</pattern>
+                            <shadedPattern>co.aikar.commands.adventure.checkerframework</shadedPattern>
+                        </relocation>
                     </relocations>
                     <dependencyReducedPomLocation>
                         ${project.build.directory}/dependency-reduced-pom.xml
@@ -209,5 +221,7 @@
         <module>sponge</module>
         <module>jda</module>
         <module>velocity</module>
+        <module>adventure/bukkit</module>
+        <module>adventure/bungee</module>
     </modules>
 </project>


### PR DESCRIPTION
I added Adventure as a module to acf. It's still a work in progress.

TODOs:

- [x] Make a proper implementation for MessageType and MessageFormatters. (take a look at the picture below)
- [ ] Check every existing message key so there's no problem with weird color codes.

![grafik](https://user-images.githubusercontent.com/15250323/103424824-dbdcb780-4bae-11eb-8266-55fc2a62debc.png)