### PR TITLE
exception check for CompletionStage instead of CompletableFuture

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -48,8 +48,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -150,8 +150,8 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
             if (passedArgs == null) return;
 
             Object obj = method.invoke(scope, passedArgs.values().toArray());
-            if (obj instanceof CompletableFuture) {
-                CompletableFuture<?> future = (CompletableFuture) obj;
+            if (obj instanceof CompletionStage<?>) {
+                CompletionStage<?> future = (CompletionStage<?>) obj;
                 future.exceptionally(t -> {
                     handleException(sender, args, t);
                     return null;


### PR DESCRIPTION
I already made a PR a while ago to handle CompletableFutures in the exception handler:

https://github.com/aikar/commands/commit/7583dc881019174e81074d3539765cb2b1083627

I realized that CompletableFuture implements CompletionStage. That PR is just a small optimization to be prepared for custom CompletionStages and is not breaking as every CompletableFuture is a CompletionStage.