### PR TITLE
Added option to disable unregistered replacement warning

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -75,6 +75,7 @@ public abstract class CommandManager<
     protected CommandHelpFormatter helpFormatter = new CommandHelpFormatter(this);
 
     protected boolean usePerIssuerLocale = false;
+    protected boolean hideUnregisteredReplacements = false;
     protected List<IssuerLocaleChangedCallback<I>> localeChangedCallbacks = new ArrayList<>();
     protected Set<Locale> supportedLanguages = new HashSet<>(Arrays.asList(Locales.ENGLISH, Locales.DUTCH, Locales.GERMAN, Locales.SPANISH, Locales.FRENCH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH, Locales.NORWEGIAN_BOKMAAL, Locales.NORWEGIAN_NYNORSK, Locales.RUSSIAN, Locales.BULGARIAN, Locales.HUNGARIAN, Locales.TURKISH, Locales.JAPANESE));
     protected Map<MessageType, MF> formatters = new IdentityHashMap<>();
@@ -270,6 +271,16 @@ public abstract class CommandManager<
     public boolean usePerIssuerLocale(boolean setting) {
         boolean old = usePerIssuerLocale;
         usePerIssuerLocale = setting;
+        return old;
+    }
+
+    public boolean hidingUnregisteredReplacements() {
+        return hideUnregisteredReplacements;
+    }
+
+    public boolean hideUnregisteredReplacements(boolean setting) {
+        boolean old = hideUnregisteredReplacements;
+        hideUnregisteredReplacements = setting;
         return old;
     }
 

--- a/core/src/main/java/co/aikar/commands/CommandReplacements.java
+++ b/core/src/main/java/co/aikar/commands/CommandReplacements.java
@@ -50,7 +50,7 @@ public class CommandReplacements {
             throw new IllegalArgumentException("Must pass a number of arguments divisible by 2.");
         }
         for (int i = 0; i < replacements.length; i += 2) {
-            addReplacement(replacements[i], replacements[i+1]);
+            addReplacement(replacements[i], replacements[i + 1]);
         }
     }
 
@@ -82,11 +82,13 @@ public class CommandReplacements {
             text = entry.getKey().matcher(text).replaceAll(entry.getValue());
         }
 
-        // check for unregistered replacements
-        Pattern pattern = Pattern.compile("%.[^\\s]*");
-        Matcher matcher = pattern.matcher(text);
-        while (matcher.find()) {
-            this.manager.log(LogLevel.ERROR, "Found unregistered replacement: " + matcher.group());
+        // check for unregistered replacements, if not disabled
+        if (!manager.hidingUnregisteredReplacements()) {
+            Pattern pattern = Pattern.compile("%.[^\\s]*");
+            Matcher matcher = pattern.matcher(text);
+            while (matcher.find()) {
+                this.manager.log(LogLevel.ERROR, "Found unregistered replacement: " + matcher.group());
+            }
         }
 
         return text;


### PR DESCRIPTION
You can now use `manager.hideUnregisteredReplacements(true);` to disable the warning.
The default value is false, so that it will only hide if the user chooses to hide them.