### PR TITLE
Adds a new pattern for CommandReplacements: %{<key>}

### DIFF
--- a/core/src/main/java/co/aikar/commands/ACFPatterns.java
+++ b/core/src/main/java/co/aikar/commands/ACFPatterns.java
@@ -49,10 +49,12 @@ final class ACFPatterns {
     public static final Pattern EQUALS = Pattern.compile("=");
     public static final Pattern FORMATTER = Pattern.compile("<c(?<color>\\d+)>(?<msg>.*?)</c\\1>", Pattern.CASE_INSENSITIVE);
     public static final Pattern I18N_STRING = Pattern.compile("\\{@@(?<key>.+?)}", Pattern.CASE_INSENSITIVE);
+    public static final Pattern REPLACEMENT_PATTERN = Pattern.compile("%\\{.[^\\s]*}");
 
 
+    private ACFPatterns() {
+    }
 
-    private ACFPatterns() {}
     @SuppressWarnings("Convert2MethodRef")
     static final Map<String, Pattern> patternCache = ExpiringMap.builder()
             .maxSize(200)
@@ -67,9 +69,7 @@ final class ACFPatterns {
      * <p>
      * The {@link #patternCache} does not contain the constant patterns defined in this class.
      *
-     * @param pattern
-     *         The raw pattern in a String.
-     *
+     * @param pattern The raw pattern in a String.
      * @return The pattern which has been cached.
      */
     public static Pattern getPattern(String pattern) {

--- a/core/src/main/java/co/aikar/commands/CommandReplacements.java
+++ b/core/src/main/java/co/aikar/commands/CommandReplacements.java
@@ -39,6 +39,7 @@ public class CommandReplacements {
 
     private final CommandManager manager;
     private final Map<String, Map.Entry<Pattern, String>> replacements = new LinkedHashMap<>();
+    private final Map<String, Map.Entry<Pattern, String>> oldReplacements = new LinkedHashMap<>();
 
     CommandReplacements(CommandManager manager) {
         this.manager = manager;
@@ -50,7 +51,7 @@ public class CommandReplacements {
             throw new IllegalArgumentException("Must pass a number of arguments divisible by 2.");
         }
         for (int i = 0; i < replacements.length; i += 2) {
-            addReplacement(replacements[i], replacements[i+1]);
+            addReplacement(replacements[i], replacements[i + 1]);
         }
     }
 
@@ -61,8 +62,10 @@ public class CommandReplacements {
     @Nullable
     private String addReplacement0(String key, String val) {
         key = ACFPatterns.PERCENTAGE.matcher(key.toLowerCase(Locale.ENGLISH)).replaceAll("");
-        Pattern pattern = Pattern.compile("%" + Pattern.quote(key) + "\\b", Pattern.CASE_INSENSITIVE);
+        Pattern oldPattern = Pattern.compile("%" + Pattern.quote(key) + "\\b", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile("%\\{" + Pattern.quote(key) + "}", Pattern.CASE_INSENSITIVE);
 
+        oldReplacements.put(key, new AbstractMap.SimpleImmutableEntry<>(oldPattern, val));
         Map.Entry<Pattern, String> entry = new AbstractMap.SimpleImmutableEntry<>(pattern, val);
         Map.Entry<Pattern, String> replaced = replacements.put(key, entry);
 
@@ -81,9 +84,12 @@ public class CommandReplacements {
         for (Map.Entry<Pattern, String> entry : replacements.values()) {
             text = entry.getKey().matcher(text).replaceAll(entry.getValue());
         }
+        for (Map.Entry<Pattern, String> entry : oldReplacements.values()) {
+            text = entry.getKey().matcher(text).replaceAll(entry.getValue());
+        }
 
         // check for unregistered replacements
-        Pattern pattern = Pattern.compile("%.[^\\s]*");
+        Pattern pattern = Pattern.compile("%\\{.[^\\s]*}");
         Matcher matcher = pattern.matcher(text);
         while (matcher.find()) {
             this.manager.log(LogLevel.ERROR, "Found unregistered replacement: " + matcher.group());

--- a/core/src/main/java/co/aikar/commands/CommandReplacements.java
+++ b/core/src/main/java/co/aikar/commands/CommandReplacements.java
@@ -61,7 +61,7 @@ public class CommandReplacements {
     @Nullable
     private String addReplacement0(String key, String val) {
         key = ACFPatterns.PERCENTAGE.matcher(key.toLowerCase(Locale.ENGLISH)).replaceAll("");
-        Pattern pattern = Pattern.compile("%\\{" + Pattern.quote(key) + "}|%" + Pattern.compile(key) + "\\b",
+        Pattern pattern = Pattern.compile("%\\{" + Pattern.quote(key) + "}|%" + Pattern.quote(key) + "\\b",
                 Pattern.CASE_INSENSITIVE);
 
         Map.Entry<Pattern, String> entry = new AbstractMap.SimpleImmutableEntry<>(pattern, val);
@@ -84,8 +84,7 @@ public class CommandReplacements {
         }
 
         // check for unregistered replacements
-        Pattern pattern = Pattern.compile("%\\{.[^\\s]*}");
-        Matcher matcher = pattern.matcher(text);
+        Matcher matcher = ACFPatterns.REPLACEMENT_PATTERN.matcher(text);
         while (matcher.find()) {
             this.manager.log(LogLevel.ERROR, "Found unregistered replacement: " + matcher.group());
         }

--- a/core/src/main/java/co/aikar/commands/CommandReplacements.java
+++ b/core/src/main/java/co/aikar/commands/CommandReplacements.java
@@ -39,7 +39,6 @@ public class CommandReplacements {
 
     private final CommandManager manager;
     private final Map<String, Map.Entry<Pattern, String>> replacements = new LinkedHashMap<>();
-    private final Map<String, Map.Entry<Pattern, String>> oldReplacements = new LinkedHashMap<>();
 
     CommandReplacements(CommandManager manager) {
         this.manager = manager;
@@ -62,10 +61,9 @@ public class CommandReplacements {
     @Nullable
     private String addReplacement0(String key, String val) {
         key = ACFPatterns.PERCENTAGE.matcher(key.toLowerCase(Locale.ENGLISH)).replaceAll("");
-        Pattern oldPattern = Pattern.compile("%" + Pattern.quote(key) + "\\b", Pattern.CASE_INSENSITIVE);
-        Pattern pattern = Pattern.compile("%\\{" + Pattern.quote(key) + "}", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile("%\\{" + Pattern.quote(key) + "}|%" + Pattern.compile(key) + "\\b",
+                Pattern.CASE_INSENSITIVE);
 
-        oldReplacements.put(key, new AbstractMap.SimpleImmutableEntry<>(oldPattern, val));
         Map.Entry<Pattern, String> entry = new AbstractMap.SimpleImmutableEntry<>(pattern, val);
         Map.Entry<Pattern, String> replaced = replacements.put(key, entry);
 
@@ -82,9 +80,6 @@ public class CommandReplacements {
         }
 
         for (Map.Entry<Pattern, String> entry : replacements.values()) {
-            text = entry.getKey().matcher(text).replaceAll(entry.getValue());
-        }
-        for (Map.Entry<Pattern, String> entry : oldReplacements.values()) {
             text = entry.getKey().matcher(text).replaceAll(entry.getValue());
         }
 


### PR DESCRIPTION
- Adds a new pattern for CommandReplacements: ```%{<key>}```
- Maintains the old pattern ```%<key>```
- Disables warnings for when the old pattern is not replaced