### PR TITLE
Unwraps InvocationTargetException

### DIFF
--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -171,10 +171,7 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
     }
 
     void handleException(CommandIssuer sender, List<String> args, Throwable e) {
-        while (e instanceof ExecutionException || e instanceof CompletionException) {
-            e = e.getCause();
-        }
-        if (e instanceof InvocationTargetException && e.getCause() instanceof InvalidCommandArgument) {
+        while (e instanceof ExecutionException || e instanceof CompletionException || e instanceof InvocationTargetException) {
             e = e.getCause();
         }
         if (e instanceof ShowCommandHelp) {


### PR DESCRIPTION
This exception is just a wrapper for the one thrown on invoked methods/constructors.

By unwrapping this we can go straight to the problem instead of scrolling down to find the real cause.
And sometimes server owners only send the first part of the Exception, leaving the cause behind.

Compare these stack traces:
Wrapped Exception: https://pastebin.com/raw/7tB7zDNn
Unwrapped Exception: https://pastebin.com/raw/7Vsy4SdL