### PR TITLE
Add Chinese(Simplified) language support.

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -76,7 +76,7 @@ public abstract class CommandManager<
 
     protected boolean usePerIssuerLocale = false;
     protected List<IssuerLocaleChangedCallback<I>> localeChangedCallbacks = new ArrayList<>();
-    protected Set<Locale> supportedLanguages = new HashSet<>(Arrays.asList(Locales.ENGLISH, Locales.DUTCH, Locales.GERMAN, Locales.SPANISH, Locales.FRENCH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH, Locales.NORWEGIAN_BOKMAAL, Locales.NORWEGIAN_NYNORSK, Locales.RUSSIAN, Locales.BULGARIAN, Locales.HUNGARIAN, Locales.TURKISH, Locales.JAPANESE));
+    protected Set<Locale> supportedLanguages = new HashSet<>(Arrays.asList(Locales.ENGLISH, Locales.DUTCH, Locales.GERMAN, Locales.SPANISH, Locales.FRENCH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH, Locales.NORWEGIAN_BOKMAAL, Locales.NORWEGIAN_NYNORSK, Locales.RUSSIAN, Locales.BULGARIAN, Locales.HUNGARIAN, Locales.TURKISH, Locales.JAPANESE, Locales.CHINESE, Locales.SIMPLIFIED_CHINESE));
     protected Map<MessageType, MF> formatters = new IdentityHashMap<>();
     protected MF defaultFormatter;
     protected int defaultHelpPerPage = 10;

--- a/languages/core/acf-core_zh.properties
+++ b/languages/core/acf-core_zh.properties
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2016-2021 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+acf-core.permission_denied=很抱歉，你没有执行此命令的权限。
+acf-core.permission_denied_parameter=很抱歉，你没有执行此命令的权限。
+acf-core.error_generic_logged=很抱歉，插件产生了内部错误。问题已输出在游戏日志中。
+acf-core.unknown_command=您输入了未知的指令，输入 <c2>/help</c2> 获得指令帮助。
+acf-core.invalid_syntax=指令用法：<c2>{command}</c2> <c3>{syntax}</c3>
+acf-core.error_prefix=错误：{message}
+acf-core.error_performing_command=很抱歉，指令执行中出现了错误。
+acf-core.info_message={message}
+acf-core.please_specify_one_of=错误：请输入 <c2>{valid}</c2> 中的某一个。
+acf-core.must_be_a_number=错误：{num} 必须是数字。
+acf-core.must_be_min_length=错误：至少需要输入 {min} 个字符。
+acf-core.must_be_max_length=错误：最多需要输入 {max} 个字符。
+acf-core.please_specify_at_most=错误：请输入一个不大于 {max} 的值。
+acf-core.please_specify_at_least=错误：请输入一个不小于 {min} 的值。
+acf-core.not_allowed_on_console=错误：控制台不能执行此命令。
+acf-core.could_not_find_player=错误：找不到名叫 <c2>{search}</c2> 的玩家。
+acf-core.no_command_matched_search=没有找到匹配 <c2>{search}</c2> 的指令。
+acf-core.help_page_information=- 页面 <c2>{page}</c2> / <c2>{totalpages}</c2> (共计 <c3>{results}</c3> 个结果)。
+acf-core.help_no_results=错误：没有更多的搜索结果。
+acf-core.help_header=<c3>=== </c3><c1>关于指令 </c1><c2>{commandprefix}{command}</c2><c1> 的使用说明</c1><c3> ===</c3>
+acf-core.help_format=<c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_header=<c3>=== </c3><c1>显示指令 </c1><c2>{commandprefix}{command}</c2><c1> 的详细使用说明</c1><c3> ===</c3>
+acf-core.help_detailed_command_format=<c1>{command}</c1> <c2>{parameters}</c2> <c3>{separator} {description}</c3>
+acf-core.help_detailed_parameter_format=<c2>{syntaxorname}</c2>: <c3>{description}</c3>
+acf-core.help_search_header=<c3>=== </c3><c1>指令 </c1><c2>{commandprefix}{command} {search}</c2><c1> 的搜索结果</c1><c3> ===</c3>

--- a/languages/minecraft/acf-minecraft_zh.properties
+++ b/languages/minecraft/acf-minecraft_zh.properties
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2016-2021 Daniel Ennis (Aikar) - MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining
+#  a copy of this software and associated documentation files (the
+#  "Software"), to deal in the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+acf-minecraft.invalid_world = 错误：该世界不存在。
+acf-minecraft.you_must_be_holding_item = 错误：你的主手上必须持有物品。
+acf-minecraft.player_is_vanished_confirm = \
+    警告：<c2>{vanished}</c2> 已被隐藏。不要暴露他们的身份！\n\
+    如果你确认这么做，请在他们的名字后面加上 <c2>:confirm</c2> 。\n\
+    例如：<c2>{vanished}:confirm</c2>
+acf-minecraft.username_too_short = 错误：名字太短，请至少输入三个字符。
+acf-minecraft.is_not_a_valid_name = 错误：<c2>{name}</c2> 不是一个可以用的名字。
+acf-minecraft.multiple_players_match = 错误：<c2>{search}</c2> 的搜索结果过多<c3>(共计{all}人)</c3>，请再详细一点。
+acf-minecraft.no_player_found_server = 没有搜索到匹配 <c2>{search}</c2> 的在线玩家。
+acf-minecraft.no_player_found_offline = 没有搜索到匹配 <c2>{search}</c2> 的在线/离线玩家。
+acf-minecraft.no_player_found = 没有搜索到匹配 <c2>{search}</c2> 的玩家。
+acf-minecraft.location_please_specify_world = 错误：请指明世界。例如：<c2>world:x,y,z</c2>。
+acf-minecraft.location_please_specify_xyz = 错误：请指明坐标x，y和z。例如：<c2>world:x,y,z</c2>。
+acf-minecraft.location_console_not_relative = 错误：控制台不能使用相对坐标来指明位置。


### PR DESCRIPTION
A potential problem: Because `LocaleManager.getMessage()` only uses `Locale.getLanguage()` and not `Locale.getCountry()`, `Locale.SIMPLIFIED_CHINESE` and `Locale. TRADITIONAL_CHINESE` will be treated as the same dialect of Chinese. This will cause only one language file to exist for Simplified Chinese and Traditional Chinese.