### PR TITLE
Add constructor based dependency injection

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -578,8 +578,11 @@ public abstract class CommandManager<
         Constructor<?> constructor = null;
         for (Constructor<?> possibleConstructor : commandClass.getConstructors()) {
             if (annotations.hasAnnotation(possibleConstructor, Dependency.class)) {
+                if (constructor != null) {
+                    throw new IllegalStateException("Command " + commandClass.getName() + " has more than one " +
+                            "constructor annotated @Depenedency.");
+                }
                 constructor = possibleConstructor;
-                break;
             }
         }
         if (commandClass.getConstructors().length == 1) {

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -597,7 +597,7 @@ public abstract class CommandManager<
         }
         for (int i = 0; i < parameters.length; i++) {
             String dependency = annotations.getAnnotationValue(parameters[i], Dependency.class);
-            String key = (key = dependency) == null || key.isEmpty() ? parameters[i].getType().getName() : key;
+            String key = dependency == null || dependency.isEmpty() ? parameters[i].getType().getName() : dependency;
             Object object = dependencies.row(parameters[i].getType()).get(key);
             if (object == null) {
                 throw new UnresolvedDependencyException("Could not find a registered instance of " +

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -586,7 +586,7 @@ public abstract class CommandManager<
             constructor = commandClass.getConstructors()[0];
         }
         if (constructor == null) {
-            throw new UnresolvedDependencyException("");
+            throw new IllegalStateException("Could not find suitable constructor for " + commandClass.getName());
         }
 
         Parameter[] parameters = constructor.getParameters();
@@ -607,7 +607,7 @@ public abstract class CommandManager<
             args[i] = object;
         }
 
-        BaseCommand instance = null;
+        BaseCommand instance;
         try {
             instance = (BaseCommand) constructor.newInstance(args);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {

--- a/core/src/main/java/co/aikar/commands/annotation/Dependency.java
+++ b/core/src/main/java/co/aikar/commands/annotation/Dependency.java
@@ -29,11 +29,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Injects a dependency into the field this is attached to.
+ * Injects a dependency into the field, constructor or parameter this is attached to.
  * Any time a new dependency is registered, this will be overwritten.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
 public @interface Dependency {
     /**
      * The key that should be used to lookup the instances, defaults to \"\"


### PR DESCRIPTION
Added constructor dependency injection to the small DI framework that already exists. This is done by adding `CommandManager#registerCommand(Class<? extends BaseCommand> commandClass)` which constructs the class then passes it into the command manager's registerCommand. If the class only has one constructor, it will attempt to use that, if not, it looks for a constructor annotated with @Dependency. Parameters can be annotated with @Dependency to specify the key