### PR TITLE
Use every subcommand for command completions

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -637,9 +637,8 @@ public abstract class BaseCommand {
 
             final List<String> cmds = new ArrayList<>();
             if (search != null) {
-                CommandRouter.CommandRouteResult result = router.matchCommand(search, true);
-                if (result != null) {
-                    cmds.addAll(completeCommand(issuer, result.cmd, result.args, commandLabel, isAsync));
+                for (RegisteredCommand<?> command : search.commands) {
+                    cmds.addAll(completeCommand(issuer, command, args, commandLabel, isAsync));
                 }
             }
 


### PR DESCRIPTION
ACF does only use one matching command to complete commands. Therefore overloaded commands doesn't get correctly completed.

This should fix this problem. There is no need to match a specific command here.

filterTabComplete(..) will remove all duplicated completions so there should be no duplicates in the completions.