### PR TITLE
Fixed spelling mistake in German translation

### DIFF
--- a/languages/core/acf-core_de.properties
+++ b/languages/core/acf-core_de.properties
@@ -20,7 +20,7 @@
 #  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 #  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-acf-core.permission_denied=Du hast nicht die benötigte Berechtigung um diesen Befehl auszuführen.
+acf-core.permission_denied=Du hast nicht die benötigte Berechtigung, um diesen Befehl auszuführen.
 acf-core.error_generic_logged=Ein Fehler ist aufgetreten. Dieses Problem wurde protokolliert. Entschuldigung für die Unannehmlichkeiten.
 acf-core.unknown_command=Unbekannter Befehl, gib <c2>/help</c2> ein, um Hilfe zu bekommen.
 acf-core.invalid_syntax=Verwendung: <c2>{command}</c2> <c3>{syntax}</c3>


### PR DESCRIPTION
"um diesen Befehl auszuführen" is a final subordinate clause and therefore needs a comma (https://www.sprachschach.de/komma-vor-um/).