### PR TITLE
Add velocity 3.0.0 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.velocitypowered</groupId>
 			<artifactId>velocity-api</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>3.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
+++ b/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
@@ -11,14 +11,13 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
-import net.kyori.text.TextComponent;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 public class ACFVelocityUtil {
 
-    @SuppressWarnings("deprecation")
     public static TextComponent color(String message) {
-        return LegacyComponentSerializer.legacy().deserialize(message);
+        return LegacyComponentSerializer.legacySection().deserialize(message);
     }
 
     public static Player findPlayerSmart(ProxyServer server, CommandIssuer issuer, String search) {

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
@@ -34,16 +34,16 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
 import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
-import net.kyori.text.format.TextFormat;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
 
 public class VelocityCommandCompletions extends CommandCompletions<VelocityCommandCompletionContext> {
 
     public VelocityCommandCompletions(ProxyServer server, CommandManager manager) {
         super(manager);
         registerAsyncCompletion("chatcolors", c -> {
-            Stream<TextFormat> colors = Stream.of(TextColor.values());
+            Stream<TextFormat> colors = NamedTextColor.NAMES.values().stream().map(namedTextColor -> namedTextColor);
             if (!c.hasConfig("colorsonly")) {
                 colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
             }

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
@@ -31,9 +31,10 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
 import co.aikar.commands.velocity.contexts.OnlinePlayer;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
-import net.kyori.text.format.TextFormat;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.Nullable;
 
 public class VelocityCommandContexts extends CommandContexts<VelocityCommandExecutionContext> {
@@ -56,7 +57,7 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
 
         registerContext(TextFormat.class, c -> {
             String first = c.popFirstArg();
-            Stream<TextFormat> colors = Stream.of(TextColor.values());
+            Stream<TextFormat> colors = NamedTextColor.NAMES.values().stream().map(namedTextColor -> namedTextColor);
             if (!c.hasFlag("colorsonly")) {
                 colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
             }
@@ -67,7 +68,7 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
                 colors = colors.filter(color -> finalFilter.equals(ACFUtil.simplifyString(color.toString())));
             }
 
-            TextColor match = ACFUtil.simpleMatch(TextColor.class, first);
+            TextColor match = NamedTextColor.NAMES.value(ACFUtil.simplifyString(first));
             if (match == null) {
                 String valid = colors.map(color -> "<c2>" + ACFUtil.simplifyString(color.toString()) + "</c2>")
                         .collect(Collectors.joining("<c1>,</c1> "));

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
@@ -41,10 +41,10 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
 import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 public class VelocityCommandManager extends
-        CommandManager<CommandSource, VelocityCommandIssuer, TextColor, VelocityMessageFormatter, VelocityCommandExecutionContext, VelocityConditionContext> {
+        CommandManager<CommandSource, VelocityCommandIssuer, NamedTextColor, VelocityMessageFormatter, VelocityCommandExecutionContext, VelocityConditionContext> {
 
     protected final ProxyServer proxy;
     protected final PluginContainer plugin;
@@ -56,10 +56,10 @@ public class VelocityCommandManager extends
     public VelocityCommandManager(ProxyServer proxy, Object plugin) {
         this.proxy = proxy;
         this.plugin = proxy.getPluginManager().getPlugin(plugin.getClass().getAnnotation(Plugin.class).id()).get();
-        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(TextColor.RED, TextColor.YELLOW, TextColor.RED));
-        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(TextColor.YELLOW, TextColor.GREEN, TextColor.WHITE));
-        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(TextColor.BLUE, TextColor.DARK_GREEN, TextColor.GREEN));
-        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(TextColor.AQUA, TextColor.GREEN, TextColor.YELLOW));
+        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(NamedTextColor.RED, NamedTextColor.YELLOW, NamedTextColor.RED));
+        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(NamedTextColor.YELLOW, NamedTextColor.GREEN, NamedTextColor.WHITE));
+        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(NamedTextColor.BLUE, NamedTextColor.DARK_GREEN, NamedTextColor.GREEN));
+        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(NamedTextColor.AQUA, NamedTextColor.GREEN, NamedTextColor.YELLOW));
 
         getLocales();
 
@@ -129,7 +129,7 @@ public class VelocityCommandManager extends
                 if (force) {
                     proxy.getCommandManager().unregister(commandName);
                 }
-                proxy.getCommandManager().register(velocityCommand, commandName);
+                proxy.getCommandManager().register(commandName, velocityCommand);
             }
             velocityCommand.isRegistered = true;
             registeredCommands.put(commandName, velocityCommand);

--- a/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
@@ -1,17 +1,16 @@
 package co.aikar.commands;
 
-import net.kyori.text.format.TextColor;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
-public class VelocityMessageFormatter extends MessageFormatter<TextColor> {
+public class VelocityMessageFormatter extends MessageFormatter<NamedTextColor> {
 
-    public VelocityMessageFormatter(TextColor... colors) {
+    public VelocityMessageFormatter(NamedTextColor... colors) {
         super(colors);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    String format(TextColor color, String message) {
-        return LegacyComponentSerializer.legacy().serialize(LegacyComponentSerializer.legacy().deserialize(message).color(color));
+    String format(NamedTextColor color, String message) {
+        return LegacyComponentSerializer.legacySection().serialize(LegacyComponentSerializer.legacySection().deserialize(message).color(color));
     }
 }

--- a/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
@@ -25,13 +25,15 @@ package co.aikar.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
 
-public class VelocityRootCommand implements Command, RootCommand {
+public class VelocityRootCommand implements SimpleCommand, RootCommand {
 
     private final VelocityCommandManager manager;
     private final String name;
@@ -75,17 +77,22 @@ public class VelocityRootCommand implements Command, RootCommand {
     }
 
     @Override
-    public void execute(CommandSource source, String[] args) {
-        execute(manager.getCommandIssuer(source), getCommandName(), args);
-    }
-
-    @Override
-    public List<String> suggest(CommandSource source, String[] args) {
-        return getTabCompletions(manager.getCommandIssuer(source), getCommandName(), args);
-    }
-
-    @Override
     public BaseCommand getDefCommand() {
         return defCommand;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        execute(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
+    }
+
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        return getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
+    }
+
+    @Override
+    public CompletableFuture<List<String>> suggestAsync(Invocation invocation) {
+        return CompletableFuture.completedFuture(getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments()));
     }
 }


### PR DESCRIPTION
Hi! I've added velocity 3.0.0 support with this PR. Here are two changes I made that may need to be looked into:
1. `NamedTextColor.NAMES.values().stream().map(namedTextColor -> namedTextColor)`
The `.map(namedTextColor -> namedTextColor)` was required, so intellij stopped complaining about not assignable types. I am not sure if that is intentional, but it seems to work.
2. 
```java
    @Override
    public CompletableFuture<List<String>> suggestAsync(Invocation invocation) {
        return CompletableFuture.completedFuture(getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments()));
    }
```

I am not sure if that needs to be implemented, but I did it either way. 

Let me know if I have to do any more changes to get this PR merged. Thanks!