### PR TITLE
update to velocity 3.0.0

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,15 +7,15 @@
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
+        <module name="acf-jda" />
+        <module name="acf-paper" />
+        <module name="example-plugin" />
         <module name="acf-sponge" />
         <module name="acf" />
-        <module name="acf-example" />
-        <module name="example-plugin" />
-        <module name="acf-brigadier" />
-        <module name="acf-paper" />
-        <module name="acf-jda" />
-        <module name="acf-core" />
         <module name="acf-velocity" />
+        <module name="acf-core" />
+        <module name="acf-brigadier" />
+        <module name="acf-example" />
         <module name="acf-bukkit" />
         <module name="acf-bungee" />
       </profile>
@@ -47,6 +47,7 @@
       <module name="acf-parent" options="" />
       <module name="acf-sponge" options="-parameters" />
       <module name="acf-velocity" options="-parameters" />
+      <module name="commands" options="-parameters" />
       <module name="example-plugin" options="-parameters" />
     </option>
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>co.aikar</groupId>
     <artifactId>acf-parent</artifactId>
-    <version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+    <version><!--VERSION-->0.5.1-SNAPSHOT<!--VERSION--></version>
     <packaging>pom</packaging>
     <name>ACF (All)</name>
     <url>https://acf.emc.gs</url>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -10,7 +10,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>acf-velocity</artifactId>
-	<version><!--VERSION-->0.5.0-SNAPSHOT<!--VERSION--></version>
+	<version><!--VERSION-->0.5.1-SNAPSHOT<!--VERSION--></version>
 
 	<name>ACF (Velocity)</name>
 

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.velocitypowered</groupId>
 			<artifactId>velocity-api</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>3.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
+++ b/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
@@ -10,15 +10,17 @@ import java.util.stream.Collectors;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-
-import net.kyori.text.TextComponent;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 public class ACFVelocityUtil {
 
-    @SuppressWarnings("deprecation")
     public static TextComponent color(String message) {
-        return LegacyComponentSerializer.legacy().deserialize(message);
+        return LegacyComponentSerializer.legacyAmpersand().deserialize(message);
     }
 
     public static Player findPlayerSmart(ProxyServer server, CommandIssuer issuer, String search) {
@@ -76,5 +78,15 @@ public class ACFVelocityUtil {
             throw new NullPointerException(String.format(message, values));
         }
         return object;
+    }
+
+    public static String getTextFormatName(TextFormat textFormat) {
+        if (textFormat instanceof NamedTextColor) {
+            return ((NamedTextColor) textFormat).toString();
+        } else if (textFormat instanceof TextDecoration) {
+            return ((TextDecoration) textFormat).toString();
+        } else {
+            return "";
+        }
     }
 }

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
@@ -23,39 +23,38 @@
 
 package co.aikar.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
 
-import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
-import net.kyori.text.format.TextFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class VelocityCommandCompletions extends CommandCompletions<VelocityCommandCompletionContext> {
 
     public VelocityCommandCompletions(ProxyServer server, CommandManager manager) {
         super(manager);
         registerAsyncCompletion("chatcolors", c -> {
-            Stream<TextFormat> colors = Stream.of(TextColor.values());
+            Set<TextFormat> colors = new HashSet<>(NamedTextColor.NAMES.values());
             if (!c.hasConfig("colorsonly")) {
-                colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
+                colors.addAll(Arrays.asList(TextDecoration.values()));
             }
             String filter = c.getConfig("filter");
             if (filter != null) {
                 Set<String> filters = Arrays.stream(ACFPatterns.COLON.split(filter)).map(ACFUtil::simplifyString)
                         .collect(Collectors.toSet());
 
-                colors = colors.filter(color -> filters.contains(ACFUtil.simplifyString(color.toString())));
+                colors.removeIf(col -> filters.contains(ACFUtil.simplifyString(ACFVelocityUtil.getTextFormatName(col))));
             }
 
-            return colors.map(color -> ACFUtil.simplifyString(color.toString())).collect(Collectors.toList());
+            return colors.stream().map(color -> ACFUtil.simplifyString(ACFVelocityUtil.getTextFormatName(color))).collect(Collectors.toList());
         });
         registerCompletion("players", c -> {
             CommandSource sender = c.getSender();

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
@@ -54,31 +54,6 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
             }
             return proxiedPlayer;
         });
-
-//        registerContext(TextFormat.class, c -> {
-//            String first = c.popFirstArg();
-//            Stream<TextFormat> colors = Stream.of(TextColor.values());
-//            if (!c.hasFlag("colorsonly")) {
-//                colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
-//            }
-//            String filter = c.getFlagValue("filter", (String) null);
-//            if (filter != null) {
-//                filter = ACFUtil.simplifyString(filter);
-//                String finalFilter = filter;
-//                colors = colors.filter(color -> finalFilter.equals(ACFUtil.simplifyString(color.toString())));
-//            }
-//
-//            TextColor match = ACFUtil.simpleMatch(TextColor.class, first);
-//            if (match == null) {
-//                String valid = colors.map(color -> "<c2>" + ACFUtil.simplifyString(color.toString()) + "</c2>")
-//                        .collect(Collectors.joining("<c1>,</c1> "));
-//
-//                throw new InvalidCommandArgument(MessageKeys.PLEASE_SPECIFY_ONE_OF, "{valid}", valid);
-//            }
-//            return match;
-//        });
-
-        // Kyori made this complicated :(
         registerContext(TextFormat.class, c -> {
             String first = c.popFirstArg();
             Set<TextFormat> colors = new HashSet<>(NamedTextColor.NAMES.values());

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
@@ -55,6 +55,30 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
             return proxiedPlayer;
         });
 
+//        registerContext(TextFormat.class, c -> {
+//            String first = c.popFirstArg();
+//            Stream<TextFormat> colors = Stream.of(TextColor.values());
+//            if (!c.hasFlag("colorsonly")) {
+//                colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
+//            }
+//            String filter = c.getFlagValue("filter", (String) null);
+//            if (filter != null) {
+//                filter = ACFUtil.simplifyString(filter);
+//                String finalFilter = filter;
+//                colors = colors.filter(color -> finalFilter.equals(ACFUtil.simplifyString(color.toString())));
+//            }
+//
+//            TextColor match = ACFUtil.simpleMatch(TextColor.class, first);
+//            if (match == null) {
+//                String valid = colors.map(color -> "<c2>" + ACFUtil.simplifyString(color.toString()) + "</c2>")
+//                        .collect(Collectors.joining("<c1>,</c1> "));
+//
+//                throw new InvalidCommandArgument(MessageKeys.PLEASE_SPECIFY_ONE_OF, "{valid}", valid);
+//            }
+//            return match;
+//        });
+
+        // Kyori made this complicated :(
         registerContext(TextFormat.class, c -> {
             String first = c.popFirstArg();
             Set<TextFormat> colors = new HashSet<>(NamedTextColor.NAMES.values());

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandIssuer.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandIssuer.java
@@ -23,14 +23,12 @@
 
 package co.aikar.commands;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import java.util.UUID;
-
-import org.jetbrains.annotations.NotNull;
-
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.UUID;
 
 public class VelocityCommandIssuer implements CommandIssuer {
     private final VelocityCommandManager manager;

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +43,6 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
 import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
-import net.kyori.text.format.TextColor;
 
 public class VelocityCommandManager extends
         CommandManager<CommandSource, VelocityCommandIssuer, TextColor, VelocityMessageFormatter, VelocityCommandExecutionContext, VelocityConditionContext> {
@@ -56,10 +57,10 @@ public class VelocityCommandManager extends
     public VelocityCommandManager(ProxyServer proxy, Object plugin) {
         this.proxy = proxy;
         this.plugin = proxy.getPluginManager().getPlugin(plugin.getClass().getAnnotation(Plugin.class).id()).get();
-        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(TextColor.RED, TextColor.YELLOW, TextColor.RED));
-        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(TextColor.YELLOW, TextColor.GREEN, TextColor.WHITE));
-        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(TextColor.BLUE, TextColor.DARK_GREEN, TextColor.GREEN));
-        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(TextColor.AQUA, TextColor.GREEN, TextColor.YELLOW));
+        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(NamedTextColor.RED, NamedTextColor.YELLOW, NamedTextColor.RED));
+        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(NamedTextColor.YELLOW, NamedTextColor.GREEN, NamedTextColor.WHITE));
+        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(NamedTextColor.BLUE, NamedTextColor.DARK_GREEN, NamedTextColor.GREEN));
+        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(NamedTextColor.AQUA, NamedTextColor.GREEN, NamedTextColor.YELLOW));
 
         getLocales();
 
@@ -129,7 +130,7 @@ public class VelocityCommandManager extends
                 if (force) {
                     proxy.getCommandManager().unregister(commandName);
                 }
-                proxy.getCommandManager().register(velocityCommand, commandName);
+                proxy.getCommandManager().register(commandName, velocityCommand);
             }
             velocityCommand.isRegistered = true;
             registeredCommands.put(commandName, velocityCommand);

--- a/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
@@ -1,7 +1,7 @@
 package co.aikar.commands;
 
-import net.kyori.text.format.TextColor;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 public class VelocityMessageFormatter extends MessageFormatter<TextColor> {
 
@@ -10,8 +10,7 @@ public class VelocityMessageFormatter extends MessageFormatter<TextColor> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     String format(TextColor color, String message) {
-        return LegacyComponentSerializer.legacy().serialize(LegacyComponentSerializer.legacy().deserialize(message).color(color));
+        return LegacyComponentSerializer.legacyAmpersand().serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(message).color(color));
     }
 }

--- a/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
@@ -29,9 +29,13 @@ import java.util.List;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.velocitypowered.api.command.Command;
+import com.velocitypowered.api.command.CommandInvocation;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.InvocableCommand;
+import com.velocitypowered.api.command.RawCommand;
+import com.velocitypowered.api.command.SimpleCommand;
 
-public class VelocityRootCommand implements Command, RootCommand {
+public class VelocityRootCommand implements SimpleCommand, RootCommand {
 
     private final VelocityCommandManager manager;
     private final String name;
@@ -75,17 +79,17 @@ public class VelocityRootCommand implements Command, RootCommand {
     }
 
     @Override
-    public void execute(CommandSource source, String[] args) {
-        execute(manager.getCommandIssuer(source), getCommandName(), args);
-    }
-
-    @Override
-    public List<String> suggest(CommandSource source, String[] args) {
-        return getTabCompletions(manager.getCommandIssuer(source), getCommandName(), args);
-    }
-
-    @Override
     public BaseCommand getDefCommand() {
         return defCommand;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        execute(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
+    }
+
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        return getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
     }
 }


### PR DESCRIPTION
This required a fair decent bit of change, mostly in the command completions and contexts sections.
Previously, `TextFormat` was used primarily as the `@chatcolor` command completion. As of velocity `3.x` using kyori adventure `4.8.x`, the hierarchy has changed. Chat formatting as been split into `NamedTextColor` (a class) for actual colors while text decorations have been placed into `TextDecoration` (an enum), both of which implement the **now empty** interface `TextFormat`. Because this interface is empty, we have no way of common methods for getting names which leads to the addition in a util class:
```java
public static String getTextFormatName(TextFormat textFormat) {
      if (textFormat instanceof NamedTextColor) {
          return ((NamedTextColor) textFormat).toString();
      } else if (textFormat instanceof TextDecoration) {
          return ((TextDecoration) textFormat).toString();
      } else {
          return "";
      }
  }
```
Unfortunately, kyori has made this pretty difficult by splitting these parts up so the above is required. Which leads to something like:
```java
@Subcommand("foo|bar")
@CommandCompletion("@chatcolors")
public void foobar(CommandSource player, TextFormat color) {
    if (color instanceof TextColor) {
        player.sendMessage(Component.text("kyori 👎", ((TextColor) color)));
    } else if (color instanceof TextDecoration) {
        player.sendMessage(Component.text("kyori 👎").decorate(((TextDecoration) color)));
    }
}
```
Comment your thoughts!