### PR TITLE
Update BukkitCommandManager.java

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -126,7 +126,7 @@ public class BukkitCommandManager extends CommandManager<
                 return;
             }
             Bukkit.getOnlinePlayers().forEach(this::readPlayerLocale);
-        }, 5, 5);
+        }, 30, 30);
 
         registerDependency(plugin.getClass(), plugin);
         registerDependency(Logger.class, plugin.getLogger());


### PR DESCRIPTION
Increases the time of the loop that watches the players online. Why does it do this? Because every 5 ticks is an overkill. 
https://i.imgur.com/psuPuYk.png