### PR TITLE
Command Visibilty Conditions

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -144,6 +144,14 @@ public abstract class BaseCommand {
      */
     @Nullable String conditions;
     /**
+     * The show conditions of the command. This may be null if no show conditions has been provided.
+     */
+    @Nullable String showConditions;
+    /**
+     * The hide conditions of the command. This may be null if no hide conditions has been provided.
+     */
+    @Nullable String hideConditions;
+    /**
      * Identifies if the command has an explicit help command annotated with {@link HelpCommand}
      */
     boolean hasHelpCommand;

--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -32,7 +32,9 @@ import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.HelpCommand;
+import co.aikar.commands.annotation.HideConditions;
 import co.aikar.commands.annotation.PreCommand;
+import co.aikar.commands.annotation.ShowConditions;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.UnknownHandler;
 import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
@@ -261,6 +263,8 @@ public abstract class BaseCommand {
         this.description = annotations.getAnnotationValue(self, Description.class, Annotations.NO_EMPTY | Annotations.REPLACEMENTS);
         this.parentSubcommand = getParentSubcommand(self);
         this.conditions = annotations.getAnnotationValue(self, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.showConditions = annotations.getAnnotationValue(self, ShowConditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.hideConditions = annotations.getAnnotationValue(self, HideConditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
 
         computePermissions(); // Must be before any subcommands so they can inherit permissions
         registerSubcommands();
@@ -646,7 +650,7 @@ public abstract class BaseCommand {
             final List<String> cmds = new ArrayList<>();
             if (search != null) {
                 CommandRouter.CommandRouteResult result = router.matchCommand(search, true);
-                if (result != null) {
+                if (result != null && this.manager.visibilityConditions.shouldTabComplete(result.cmd, issuer)) {
                     cmds.addAll(completeCommand(issuer, result.cmd, result.args, commandLabel, isAsync));
                 }
             }
@@ -677,7 +681,9 @@ public abstract class BaseCommand {
                 }
 
                 String[] split = ACFPatterns.SPACE.split(value.prefSubCommand);
-                cmds.add(split[cmdIndex]);
+                if (this.manager.visibilityConditions.shouldTabComplete(value, issuer)) {
+                    cmds.add(split[cmdIndex]);
+                }
             }
         }
         return new ArrayList<>(cmds);

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -69,6 +69,7 @@ public abstract class CommandManager<
     protected Map<String, RootCommand> rootCommands = new HashMap<>();
     protected final CommandReplacements replacements = new CommandReplacements(this);
     protected final CommandConditions<I, CEC, CC> conditions = new CommandConditions<>(this);
+    protected final CommandVisibilityConditions<I, CC> visibilityConditions = new CommandVisibilityConditions<>(this);
     protected ExceptionHandler defaultExceptionHandler = null;
     boolean logUnhandledExceptions = true;
     protected Table<Class<?>, String, Object> dependencies = new Table<>();
@@ -132,6 +133,10 @@ public abstract class CommandManager<
 
     public CommandConditions<I, CEC, CC> getCommandConditions() {
         return conditions;
+    }
+
+    public CommandVisibilityConditions<I, CC> getCommandVisibilityConditions() {
+        return visibilityConditions;
     }
 
     /**

--- a/core/src/main/java/co/aikar/commands/CommandVisibilityConditions.java
+++ b/core/src/main/java/co/aikar/commands/CommandVisibilityConditions.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016-2017 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+@SuppressWarnings("BooleanMethodIsAlwaysInverted") // No IDEA, you are wrong
+public class CommandVisibilityConditions<
+        I extends CommandIssuer,
+        CC extends ConditionContext<I>
+        > {
+    private CommandManager manager;
+    private Map<String, VisibilityCondition<I>> visibilityConditions = new HashMap<>();
+
+    CommandVisibilityConditions(CommandManager manager) {
+        this.manager = manager;
+    }
+
+    public VisibilityCondition<I> addCondition(@NotNull String id, @NotNull VisibilityCondition<I> handler) {
+        return this.visibilityConditions.put(id.toLowerCase(Locale.ENGLISH), handler);
+    }
+
+    boolean shouldTabComplete(RegisteredCommand cmd, CommandIssuer issuer) {
+        return validateShowConditions(cmd, issuer) && !validateHideConditions(cmd, issuer);
+    }
+
+    private boolean validateShowConditions(RegisteredCommand cmd, CommandIssuer issuer) {
+        return validateConditions(cmd, cmd.showConditions, issuer, true)
+                && validateShowConditions(cmd, cmd.scope, issuer);
+    }
+
+    private boolean validateShowConditions(RegisteredCommand cmd, BaseCommand scope, CommandIssuer issuer) {
+        return validateConditions(cmd, scope.showConditions, issuer, true)
+                && (scope.parentCommand == null || validateShowConditions(cmd, scope.parentCommand, issuer));
+    }
+
+    private boolean validateHideConditions(RegisteredCommand cmd, CommandIssuer issuer) {
+        return validateConditions(cmd, cmd.hideConditions, issuer, false)
+                || validateHideConditions(cmd, cmd.scope, issuer);
+    }
+
+    private boolean validateHideConditions(RegisteredCommand cmd, BaseCommand scope, CommandIssuer issuer) {
+        return validateConditions(cmd, scope.hideConditions, issuer, false)
+                || (scope.parentCommand != null && validateHideConditions(cmd, scope.parentCommand, issuer));
+    }
+
+    private boolean validateConditions(RegisteredCommand cmd, String conditions, CommandIssuer issuer, boolean defaultResult) {
+        if (conditions == null) {
+            return defaultResult;
+        }
+
+        conditions = this.manager.getCommandReplacements().replace(conditions);
+        String[] splitConditions = ACFPatterns.PIPE.split(conditions);
+        Boolean[] results = new Boolean[splitConditions.length];
+        for (int i = 0; i < splitConditions.length; i++) {
+            String[] split = ACFPatterns.COLON.split(splitConditions[i], 2);
+            String id = split[0].toLowerCase(Locale.ENGLISH);
+            VisibilityCondition<I> visibilityCondition = this.visibilityConditions.get(id);
+            if (visibilityCondition == null) {
+                this.manager.log(LogLevel.ERROR, "Could not find command visibility condition " + id + " for " + cmd.method.getName());
+                continue;
+            }
+
+            String config = split.length == 2 ? split[1] : null;
+            //noinspection unchecked
+            CC conditionContext = (CC) this.manager.createConditionContext(issuer, config);
+            results[i] = visibilityCondition.validateCondition(conditionContext);
+        }
+        return Arrays.stream(results).allMatch(Boolean.TRUE::equals);
+    }
+
+    public interface VisibilityCondition<I extends CommandIssuer> {
+        boolean validateCondition(ConditionContext<I> context);
+    }
+}

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -29,7 +29,9 @@ import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.HelpSearchTags;
+import co.aikar.commands.annotation.HideConditions;
 import co.aikar.commands.annotation.Private;
+import co.aikar.commands.annotation.ShowConditions;
 import co.aikar.commands.annotation.Syntax;
 import co.aikar.commands.contexts.ContextResolver;
 import org.jetbrains.annotations.Nullable;
@@ -98,6 +100,8 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
         this.complete = annotations.getAnnotationValue(method, CommandCompletion.class, Annotations.DEFAULT_EMPTY); // no replacements as it should be per-issuer
         this.helpText = annotations.getAnnotationValue(method, Description.class, Annotations.REPLACEMENTS | Annotations.DEFAULT_EMPTY);
         this.conditions = annotations.getAnnotationValue(method, Conditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.showConditions = annotations.getAnnotationValue(method, ShowConditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
+        this.hideConditions = annotations.getAnnotationValue(method, HideConditions.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
         this.helpSearchTags = annotations.getAnnotationValue(method, HelpSearchTags.class, Annotations.REPLACEMENTS | Annotations.NO_EMPTY);
         this.syntaxText = annotations.getAnnotationValue(method, Syntax.class, Annotations.REPLACEMENTS);
 

--- a/core/src/main/java/co/aikar/commands/RegisteredCommand.java
+++ b/core/src/main/java/co/aikar/commands/RegisteredCommand.java
@@ -68,6 +68,8 @@ public class RegisteredCommand<CEC extends CommandExecutionContext<CEC, ? extend
     String permission;
     String complete;
     String conditions;
+    String showConditions;
+    String hideConditions;
     public String helpSearchTags;
 
     boolean isPrivate;

--- a/core/src/main/java/co/aikar/commands/annotation/HideConditions.java
+++ b/core/src/main/java/co/aikar/commands/annotation/HideConditions.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2021 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies visibility conditions that must be met in order to hide this
+ * subcommand from the tab completion. If the conditions are met it will
+ * overwrite {@code @ShowCommand}
+ *
+ * @see {@link co.aikar.commands.CommandVisibilityConditions}
+ * @see {@link co.aikar.commands.annotation.ShowConditions}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface HideConditions {
+    String value();
+}

--- a/core/src/main/java/co/aikar/commands/annotation/ShowConditions.java
+++ b/core/src/main/java/co/aikar/commands/annotation/ShowConditions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2021 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies visibility conditions that must be met in order to show this
+ * subcommand in the tab completion
+ *
+ * @see {@link co.aikar.commands.CommandVisibilityConditions}
+ * @see {@link co.aikar.commands.annotation.HideConditions}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface ShowConditions {
+    String value();
+}


### PR DESCRIPTION
Hi! I added this feature for one of my plugins, so I thought why not make a PR for it because people might find useful.

As the title suggest it adds a way to programmatically show or hide a subcommand, it only change the tab completion like `@Private`.

### How it works
1. You register a condition :
```java
commandManager.getCommandVisibilityConditions().addCondition("creative", (context) -> {
    if (!context.getIssuer().isPlayer()) return true;
    return context.getIssuer().getPlayer().getGameMode() == GameMode.CREATIVE;
});

commandManager.getCommandVisibilityConditions().addCondition("flying", (context) -> {
    if (!context.getIssuer().isPlayer()) return true;
    return context.getIssuer().getPlayer().isFlying();
});
```
2. You use it with either `@ShowCommand` or `@HideCommand` :
```java
@Subcommand("example1")
@ShowCommand("creative")
public void firstExample(CommandSender sender) {
    ...
}

@Subcommand("example2")
@HideCommand("creative")
public void secondExample(CommandSender sender) {
    ...
}

@Subcommand("example3")
@ShowCommand("creative")
@HideCommand("flying")
public void thirdExample(CommandSender sender) {
    ...
}
```
3. That's all you have to do to make it work.

So what is it doing in game :
- In the first example, the subcommand `example1` is only shown in the tab completion if the player is in gamemode creative, this is because with `@ShowCommand` the subcommand is hidden by default and is only shown when all conditions return true.
- In the second example, the subcommand `example2` is only shown in the tab completion if the player is **not** in gamemode creative, this is because with `@HideCommand` the subcommand is shown by default and is only hidden when all conditions return true.
- And in the third example, the subcommand `example3` is only shown in the tab completion if the player is in gamemode creative **and** not flying, this is because `@HideCommand` takes precedence over `@ShowCommand`.

### Condition Configs
Like normal conditions, configs are available here is an example :
```java
commandManager.getCommandVisibilityConditions().addCondition("height", (context) -> {
    if (!context.getIssuer().isPlayer()) return true;

    final int min = context.getConfigValue("min", -1);
    final int max = context.getConfigValue("max", -1);
    final double height = context.getIssuer().getPlayer().getHeight();

    return min < height && (max == -1 || max > height);
});
```
```java
@Subcommand("example")
@ShowCommand("height:min=64,max=128")
public void example(CommandSender sender) {
    ...
}
```
In this example the subcommand `example` is only shown when the player is between Y 64 and Y 128.


**Note :** You can chain conditions using `|` between them.