### PR TITLE
Update to the final release of JDA 4.x

### DIFF
--- a/jda/pom.xml
+++ b/jda/pom.xml
@@ -41,9 +41,8 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <name>jcenter-bintray</name>
-            <url>https://jcenter.bintray.com</url>
+            <id>m2-dv8tion</id>
+            <url>https://m2.dv8tion.net/releases</url>
         </repository>
     </repositories>
 
@@ -57,7 +56,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.2.0_168</version>
+            <version>4.4.0_350</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
As of 11/26/2021, the final release of JDA 4.x has been marked as the official LTS for the 4.x series. (https://github.com/DV8FromTheWorld/JDA/releases/tag/v4.4.0). 

This PR compiles against the latest version. Minimal testing has been done without seeing many issues. Compilation works fine.