### PR TITLE
Port Velocity to 3.1.0

### DIFF
--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.velocitypowered</groupId>
 			<artifactId>velocity-api</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
+++ b/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
@@ -1,5 +1,11 @@
 package co.aikar.commands;
 
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -7,18 +13,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.velocitypowered.api.command.CommandSource;
-import com.velocitypowered.api.proxy.Player;
-import com.velocitypowered.api.proxy.ProxyServer;
-
-import net.kyori.text.TextComponent;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
-
 public class ACFVelocityUtil {
 
     @SuppressWarnings("deprecation")
     public static TextComponent color(String message) {
-        return LegacyComponentSerializer.legacy().deserialize(message);
+        return LegacyComponentSerializer.legacy('&').deserialize(message);
     }
 
     public static Player findPlayerSmart(ProxyServer server, CommandIssuer issuer, String search) {

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandCompletions.java
@@ -23,27 +23,26 @@
 
 package co.aikar.commands;
 
+import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.velocitypowered.api.command.CommandSource;
-import com.velocitypowered.api.proxy.Player;
-import com.velocitypowered.api.proxy.ProxyServer;
-
-import co.aikar.commands.apachecommonslang.ApacheCommonsLangUtil;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
-import net.kyori.text.format.TextFormat;
-
 public class VelocityCommandCompletions extends CommandCompletions<VelocityCommandCompletionContext> {
 
     public VelocityCommandCompletions(ProxyServer server, CommandManager manager) {
         super(manager);
         registerAsyncCompletion("chatcolors", c -> {
-            Stream<TextFormat> colors = Stream.of(TextColor.values());
+            Stream<TextFormat> colors = Stream.of(NamedTextColor.NAMES.values().toArray(new TextFormat[0]));
             if (!c.hasConfig("colorsonly")) {
                 colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
             }

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandContexts.java
@@ -23,18 +23,17 @@
 
 package co.aikar.commands;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import co.aikar.commands.velocity.contexts.OnlinePlayer;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-
-import co.aikar.commands.velocity.contexts.OnlinePlayer;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
-import net.kyori.text.format.TextFormat;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class VelocityCommandContexts extends CommandContexts<VelocityCommandExecutionContext> {
 
@@ -56,7 +55,7 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
 
         registerContext(TextFormat.class, c -> {
             String first = c.popFirstArg();
-            Stream<TextFormat> colors = Stream.of(TextColor.values());
+            Stream<TextFormat> colors = Stream.of(NamedTextColor.NAMES.values().toArray(new TextFormat[0]));
             if (!c.hasFlag("colorsonly")) {
                 colors = Stream.concat(colors, Stream.of(TextDecoration.values()));
             }
@@ -67,7 +66,7 @@ public class VelocityCommandContexts extends CommandContexts<VelocityCommandExec
                 colors = colors.filter(color -> finalFilter.equals(ACFUtil.simplifyString(color.toString())));
             }
 
-            TextColor match = ACFUtil.simpleMatch(TextColor.class, first);
+            NamedTextColor match = NamedTextColor.NAMES.value(ACFUtil.simplifyString(first));
             if (match == null) {
                 String valid = colors.map(color -> "<c2>" + ACFUtil.simplifyString(color.toString()) + "</c2>")
                         .collect(Collectors.joining("<c1>,</c1> "));

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandIssuer.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandIssuer.java
@@ -23,14 +23,12 @@
 
 package co.aikar.commands;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import java.util.UUID;
-
-import org.jetbrains.annotations.NotNull;
-
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.UUID;
 
 public class VelocityCommandIssuer implements CommandIssuer {
     private final VelocityCommandManager manager;

--- a/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityCommandManager.java
@@ -23,6 +23,18 @@
 
 package co.aikar.commands;
 
+import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
+import com.velocitypowered.api.command.CommandMeta;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,18 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.velocitypowered.api.command.CommandSource;
-import com.velocitypowered.api.plugin.Plugin;
-import com.velocitypowered.api.plugin.PluginContainer;
-import com.velocitypowered.api.proxy.Player;
-import com.velocitypowered.api.proxy.ProxyServer;
-
-import co.aikar.commands.apachecommonslang.ApacheCommonsExceptionUtil;
-import net.kyori.text.format.TextColor;
 
 public class VelocityCommandManager extends
         CommandManager<CommandSource, VelocityCommandIssuer, TextColor, VelocityMessageFormatter, VelocityCommandExecutionContext, VelocityConditionContext> {
@@ -56,10 +56,10 @@ public class VelocityCommandManager extends
     public VelocityCommandManager(ProxyServer proxy, Object plugin) {
         this.proxy = proxy;
         this.plugin = proxy.getPluginManager().getPlugin(plugin.getClass().getAnnotation(Plugin.class).id()).get();
-        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(TextColor.RED, TextColor.YELLOW, TextColor.RED));
-        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(TextColor.YELLOW, TextColor.GREEN, TextColor.WHITE));
-        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(TextColor.BLUE, TextColor.DARK_GREEN, TextColor.GREEN));
-        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(TextColor.AQUA, TextColor.GREEN, TextColor.YELLOW));
+        this.formatters.put(MessageType.ERROR, defaultFormatter = new VelocityMessageFormatter(NamedTextColor.RED, NamedTextColor.YELLOW, NamedTextColor.RED));
+        this.formatters.put(MessageType.SYNTAX, new VelocityMessageFormatter(NamedTextColor.YELLOW, NamedTextColor.GREEN, NamedTextColor.WHITE));
+        this.formatters.put(MessageType.INFO, new VelocityMessageFormatter(NamedTextColor.BLUE, NamedTextColor.DARK_GREEN, NamedTextColor.GREEN));
+        this.formatters.put(MessageType.HELP, new VelocityMessageFormatter(NamedTextColor.AQUA, NamedTextColor.GREEN, NamedTextColor.YELLOW));
 
         getLocales();
 
@@ -129,7 +129,10 @@ public class VelocityCommandManager extends
                 if (force) {
                     proxy.getCommandManager().unregister(commandName);
                 }
-                proxy.getCommandManager().register(velocityCommand, commandName);
+                CommandMeta meta = proxy.getCommandManager()
+                        .metaBuilder(commandName)
+                        .build();
+                proxy.getCommandManager().register(meta, velocityCommand);
             }
             velocityCommand.isRegistered = true;
             registeredCommands.put(commandName, velocityCommand);

--- a/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityMessageFormatter.java
@@ -1,7 +1,7 @@
 package co.aikar.commands;
 
-import net.kyori.text.format.TextColor;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 public class VelocityMessageFormatter extends MessageFormatter<TextColor> {
 
@@ -12,6 +12,6 @@ public class VelocityMessageFormatter extends MessageFormatter<TextColor> {
     @Override
     @SuppressWarnings("deprecation")
     String format(TextColor color, String message) {
-        return LegacyComponentSerializer.legacy().serialize(LegacyComponentSerializer.legacy().deserialize(message).color(color));
+        return LegacyComponentSerializer.legacy('&').serialize(LegacyComponentSerializer.legacy('&').deserialize(message).color(color));
     }
 }

--- a/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
@@ -30,8 +30,9 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
 
-public class VelocityRootCommand implements Command, RootCommand {
+public class VelocityRootCommand implements SimpleCommand, RootCommand {
 
     private final VelocityCommandManager manager;
     private final String name;
@@ -75,13 +76,13 @@ public class VelocityRootCommand implements Command, RootCommand {
     }
 
     @Override
-    public void execute(CommandSource source, String[] args) {
-        execute(manager.getCommandIssuer(source), getCommandName(), args);
+    public void execute(Invocation invocation) {
+        execute(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
     }
 
     @Override
-    public List<String> suggest(CommandSource source, String[] args) {
-        return getTabCompletions(manager.getCommandIssuer(source), getCommandName(), args);
+    public List<String> suggest(Invocation invocation) {
+        return getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments());
     }
 
     @Override


### PR DESCRIPTION
Ported Velocity to 3.1.0, I've tested it, and both command execution and completion seem to work as they should.
The main problem with this port was that old Velocity used pre 1.16 colors. However, the new Velocity didn't have any bindings for it. So, I've replaced it with NamedTextColor.

I've tried to make a few changes. I hope I didn't mess things up! Merry Christmas!