### PR TITLE
Fixes /help <plugin> messages not localized #296

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitRootCommand.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitRootCommand.java
@@ -51,15 +51,18 @@ public class BukkitRootCommand extends Command implements RootCommand, PluginIde
     @Override
     public String getDescription() {
         RegisteredCommand command = getDefaultRegisteredCommand();
+        String description = null;
 
         if (command != null && !command.getHelpText().isEmpty()) {
-            return command.getHelpText();
+            description = command.getHelpText();
+        } else if (command != null && command.scope.description != null) {
+            description = command.scope.description;
+        } else if (defCommand.description != null) {
+            description = defCommand.description;
         }
-        if (command != null && command.scope.description != null) {
-            return command.scope.description;
-        }
-        if (defCommand.description != null) {
-            return defCommand.description;
+
+        if (description != null) {
+            return manager.getLocales().replaceI18NStrings(description);
         }
         return super.getDescription();
     }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6441328/151685088-444beccb-ee53-45a8-8c73-bf92ef7c4f6f.png)

After:
![image](https://user-images.githubusercontent.com/6441328/151685084-2f02ed86-5a71-41d7-993a-14999f059be4.png)
