### PR TITLE
feat: add plugin description to dependency injection

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandManager.java
@@ -40,6 +40,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.help.GenericCommandHelpTopic;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -141,6 +142,7 @@ public class BukkitCommandManager extends CommandManager<
         registerDependency(BukkitScheduler.class, Bukkit.getScheduler());
         registerDependency(ScoreboardManager.class, Bukkit.getScoreboardManager());
         registerDependency(ItemFactory.class, Bukkit.getItemFactory());
+        registerDependency(PluginDescriptionFile.class, plugin.getDescription());
     }
 
     @NotNull

--- a/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
+++ b/bungee/src/main/java/co/aikar/commands/BungeeCommandManager.java
@@ -29,6 +29,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginDescription;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -75,6 +76,7 @@ public class BungeeCommandManager extends CommandManager<
         // TODO more default dependencies for bungee
         registerDependency(plugin.getClass(), plugin);
         registerDependency(Plugin.class, plugin);
+        registerDependency(PluginDescription.class, plugin.getDescription());
     }
 
     public Plugin getPlugin() {


### PR DESCRIPTION
Add option to get plugin description file for queries in plugins
## Example Usage
```java
@Dependency
private PluginDescriptionFile description;

description.getAuthor(); // get current author
```
I will update the wiki page after the PR has been accepted.
