### PR TITLE
Add deregister ability to completions and contexts

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandCompletions.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletions.java
@@ -83,12 +83,12 @@ public class CommandCompletions<C extends CommandCompletionContext> {
     }
 
     /**
-     * Deregister a completion handler.
+     * Unregister a completion handler.
      * @param id
      * @return
      * @throws IllegalStateException If the completion couldn't be found
      */
-    public CommandCompletionHandler deregisterCompletion(String id) {
+    public CommandCompletionHandler unregisterCompletion(String id) {
         if (!this.completionMap.containsKey(id)) {
             throw new IllegalStateException("The supplied key " + id + " does not exist in any completions");
         }

--- a/core/src/main/java/co/aikar/commands/CommandCompletions.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletions.java
@@ -89,7 +89,7 @@ public class CommandCompletions<C extends CommandCompletionContext> {
      * @throws IllegalStateException If the completion couldn't be found
      */
     public CommandCompletionHandler deregisterCompletion(String id) {
-        if (this.completionMap.containsKey(id)) {
+        if (!this.completionMap.containsKey(id)) {
             throw new IllegalStateException("The supplied key " + id + " does not exist in any completions");
         }
 

--- a/core/src/main/java/co/aikar/commands/CommandCompletions.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletions.java
@@ -82,6 +82,12 @@ public class CommandCompletions<C extends CommandCompletionContext> {
         return this.completionMap.put(prepareCompletionId(id), handler);
     }
 
+    /**
+     * Deregister a completion handler.
+     * @param id
+     * @return
+     * @throws IllegalStateException If the completion couldn't be found
+     */
     public CommandCompletionHandler deregisterCompletion(String id) {
         if (this.completionMap.containsKey(id)) {
             throw new IllegalStateException("The supplied key " + id + " does not exist in any completions");

--- a/core/src/main/java/co/aikar/commands/CommandCompletions.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletions.java
@@ -82,6 +82,14 @@ public class CommandCompletions<C extends CommandCompletionContext> {
         return this.completionMap.put(prepareCompletionId(id), handler);
     }
 
+    public CommandCompletionHandler deregisterCompletion(String id) {
+        if (this.completionMap.containsKey(id)) {
+            throw new IllegalStateException("The supplied key " + id + " does not exist in any completions");
+        }
+
+        return this.completionMap.remove(id);
+    }
+
     /**
      * Registr a completion handler to provide command completions based on the user input.
      * This handler is declared to be safe to be executed asynchronously.

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -518,6 +518,29 @@ public abstract class CommandManager<
 
         dependencies.put(clazz, key, instance);
     }
+    
+    /**
+     * Unregisters an instance of the class, it will no longer be able to be injected
+     * 
+     * @param clazz the class the injector should look for to remove
+     */
+    public <T> void unregisterDependency(Class<? extends T> clazz) {
+        unregisterDependency(clazz, clazz.getName());
+    }
+
+    /**
+     * Unregisters an instance of the class, it will no longer be able to be injected
+     * 
+     * @param clazz the class the injector should look for to remove
+     * @param key   the key which needs to be present if that
+     */
+    public <T> void unregisterDependency(Class<? extends T> clazz, String key) {
+        if (!dependencies.containsKey(clazz, key)) {
+            throw new IllegalStateException("Unable to deregister a dependency of " + clazz.getName() + " with the key " + key + " because it wasn't registered");
+        }
+
+        dependencies.remove(clazz, key);
+    }
 
     /**
      * Attempts to inject instances of classes registered with {@link CommandManager#registerDependency(Class, Object)}

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -523,6 +523,7 @@ public abstract class CommandManager<
      * Deregisters an instance of the class, it will no longer be able to be injected
      * 
      * @param clazz the class the injector should look for to remove
+     * @throws IllegalStateException If the dependency was not found.
      */
     public <T> void deregisterDependency(Class<? extends T> clazz) {
         deregisterDependency(clazz, clazz.getName());
@@ -533,6 +534,7 @@ public abstract class CommandManager<
      * 
      * @param clazz the class the injector should look for to remove
      * @param key   the key which needs to be present if that
+     * @throws IllegalStateException If the dependency was not found.
      */
     public <T> void deregisterDependency(Class<? extends T> clazz, String key) {
         if (!dependencies.containsKey(clazz, key)) {

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -520,21 +520,21 @@ public abstract class CommandManager<
     }
     
     /**
-     * Unregisters an instance of the class, it will no longer be able to be injected
+     * Deregisters an instance of the class, it will no longer be able to be injected
      * 
      * @param clazz the class the injector should look for to remove
      */
-    public <T> void unregisterDependency(Class<? extends T> clazz) {
-        unregisterDependency(clazz, clazz.getName());
+    public <T> void deregisterDependency(Class<? extends T> clazz) {
+        deregisterDependency(clazz, clazz.getName());
     }
 
     /**
-     * Unregisters an instance of the class, it will no longer be able to be injected
+     * Deregisters an instance of the class, it will no longer be able to be injected
      * 
      * @param clazz the class the injector should look for to remove
      * @param key   the key which needs to be present if that
      */
-    public <T> void unregisterDependency(Class<? extends T> clazz, String key) {
+    public <T> void deregisterDependency(Class<? extends T> clazz, String key) {
         if (!dependencies.containsKey(clazz, key)) {
             throw new IllegalStateException("Unable to deregister a dependency of " + clazz.getName() + " with the key " + key + " because it wasn't registered");
         }

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -525,7 +525,7 @@ public abstract class CommandManager<
      * @param clazz the class the injector should look for to remove
      * @throws IllegalStateException If the dependency was not found.
      */
-    public <T> void deregisterDependency(Class<? extends T> clazz) {
+    public <T> void unregisterDependency(Class<? extends T> clazz) {
         unregisterDependency(clazz, clazz.getName());
     }
 
@@ -538,7 +538,7 @@ public abstract class CommandManager<
      */
     public <T> void unregisterDependency(Class<? extends T> clazz, String key) {
         if (!dependencies.containsKey(clazz, key)) {
-            throw new IllegalStateException("Unable to deregister a dependency of " + clazz.getName() + " with the key " + key + " because it wasn't registered");
+            throw new IllegalStateException("Unable to unregister a dependency of " + clazz.getName() + " with the key " + key + " because it wasn't registered");
         }
 
         dependencies.remove(clazz, key);

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -520,23 +520,23 @@ public abstract class CommandManager<
     }
     
     /**
-     * Deregisters an instance of the class, it will no longer be able to be injected
+     * Unregisters an instance of the class, it will no longer be able to be injected
      * 
      * @param clazz the class the injector should look for to remove
      * @throws IllegalStateException If the dependency was not found.
      */
     public <T> void deregisterDependency(Class<? extends T> clazz) {
-        deregisterDependency(clazz, clazz.getName());
+        unregisterDependency(clazz, clazz.getName());
     }
 
     /**
-     * Deregisters an instance of the class, it will no longer be able to be injected
+     * Unregisters an instance of the class, it will no longer be able to be injected
      * 
      * @param clazz the class the injector should look for to remove
      * @param key   the key which needs to be present if that
      * @throws IllegalStateException If the dependency was not found.
      */
-    public <T> void deregisterDependency(Class<? extends T> clazz, String key) {
+    public <T> void unregisterDependency(Class<? extends T> clazz, String key) {
         if (!dependencies.containsKey(clazz, key)) {
             throw new IllegalStateException("Unable to deregister a dependency of " + clazz.getName() + " with the key " + key + " because it wasn't registered");
         }


### PR DESCRIPTION
- feat: add deregister methods to completions and dependencies
- fix: change unregister to deregister
- feat: add javadocs to deregisterCompleition
- fix: add throws to javadocs for dependency methods

This might not be best practice but I would like this functionality. 
