### PR TITLE
Fix NullPointerException when attempting to parse a location relative to the player's position with the `~` term

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,15 +7,15 @@
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
+        <module name="acf-jda" />
+        <module name="acf-paper" />
+        <module name="example-plugin" />
         <module name="acf-sponge" />
         <module name="acf" />
-        <module name="acf-example" />
-        <module name="example-plugin" />
-        <module name="acf-brigadier" />
-        <module name="acf-paper" />
-        <module name="acf-jda" />
-        <module name="acf-core" />
         <module name="acf-velocity" />
+        <module name="acf-core" />
+        <module name="acf-brigadier" />
+        <module name="acf-example" />
         <module name="acf-bukkit" />
         <module name="acf-bungee" />
       </profile>

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandContexts.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandContexts.java
@@ -210,9 +210,9 @@ public class BukkitCommandContexts extends CommandContexts<BukkitCommandExecutio
                 throw new InvalidCommandArgument(MinecraftMessageKeys.LOCATION_PLEASE_SPECIFY_XYZ);
             }
 
-            Double x = ACFUtil.parseDouble(split[0]);
-            Double y = ACFUtil.parseDouble(split[1]);
-            Double z = ACFUtil.parseDouble(split[2]);
+            Double x = ACFUtil.parseDouble(split[0], rel ? 0.0D : null);
+            Double y = ACFUtil.parseDouble(split[1], rel ? 0.0D : null);
+            Double z = ACFUtil.parseDouble(split[2], rel ? 0.0D : null);
 
             if (sourceLoc != null && rel) {
                 x += sourceLoc.getX();


### PR DESCRIPTION
A NullPointerException is thrown when attempting to add on to the parsed `x`, `y`, and `z` doubles as the `ACFUtil#parseDouble(String)` method fallbacks to null if unable to parse the provided string.