### PR TITLE
Add allow illegal name manager option

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -47,6 +47,7 @@
       <module name="acf-parent" options="" />
       <module name="acf-sponge" options="-parameters" />
       <module name="acf-velocity" options="-parameters" />
+      <module name="commands" options="-parameters" />
       <module name="example-plugin" options="-parameters" />
     </option>
   </component>

--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
@@ -282,7 +282,7 @@ public class ACFBukkitUtil {
 
         //noinspection Duplicates
         if (matches.isEmpty()) {
-            if (!isValidName(name)) {
+            if (!isValidName(name, issuer.getManager())) {
                 issuer.sendError(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
                 return null;
             }
@@ -319,8 +319,8 @@ public class ACFBukkitUtil {
     }
 
 
-    public static boolean isValidName(String name) {
-        return name != null && !name.isEmpty() && ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches();
+    public static boolean isValidName(String name, CommandManager manager) {
+        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     static boolean isValidItem(ItemStack item) {

--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
@@ -318,9 +318,13 @@ public class ACFBukkitUtil {
         }
     }
 
+    @Deprecated
+    public static boolean isValidName(String name) {
+        return isValidName(name, null);
+    }
 
     public static boolean isValidName(String name, CommandManager manager) {
-        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
+        return name != null && !name.isEmpty() && ((manager != null && manager.isAllowInvalidName()) || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     static boolean isValidItem(ItemStack item) {

--- a/bukkit/src/main/java/co/aikar/commands/BukkitCommandContexts.java
+++ b/bukkit/src/main/java/co/aikar/commands/BukkitCommandContexts.java
@@ -145,7 +145,7 @@ public class BukkitCommandContexts extends CommandContexts<BukkitCommandExecutio
                 offlinePlayer = Bukkit.getOfflinePlayer(name);
             }
             if (offlinePlayer == null || (!offlinePlayer.hasPlayedBefore() && !offlinePlayer.isOnline())) {
-                if (!c.hasFlag("uuid") && !isValidName(name)) {
+                if (!c.hasFlag("uuid") && !isValidName(name, manager)) {
                     throw new InvalidCommandArgument(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
                 }
                 throw new InvalidCommandArgument(MinecraftMessageKeys.NO_PLAYER_FOUND_OFFLINE,

--- a/bungee/src/main/java/co/aikar/commands/ACFBungeeUtil.java
+++ b/bungee/src/main/java/co/aikar/commands/ACFBungeeUtil.java
@@ -124,7 +124,7 @@ public class ACFBungeeUtil {
         }
 
         if (matches.isEmpty()) {
-            if (!isValidName(name)) {
+            if (!isValidName(name, issuer.getManager())) {
                 issuer.sendError(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
                 return null;
             }
@@ -149,8 +149,8 @@ public class ACFBungeeUtil {
         throw new IllegalStateException("You may not use the ACFBungeeUtil#findPlayerSmart(CommandSender) async to the command execution.");
     }
 
-    public static boolean isValidName(String name) {
-        return name != null && !name.isEmpty() && ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches();
+    public static boolean isValidName(String name, CommandManager manager) {
+        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     public static <T> T validate(T object, String message, Object... values) {

--- a/bungee/src/main/java/co/aikar/commands/ACFBungeeUtil.java
+++ b/bungee/src/main/java/co/aikar/commands/ACFBungeeUtil.java
@@ -149,8 +149,13 @@ public class ACFBungeeUtil {
         throw new IllegalStateException("You may not use the ACFBungeeUtil#findPlayerSmart(CommandSender) async to the command execution.");
     }
 
+    @Deprecated
+    public static boolean isValidName(String name) {
+        return isValidName(name, null);
+    }
+
     public static boolean isValidName(String name, CommandManager manager) {
-        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
+        return name != null && !name.isEmpty() && ((manager != null && manager.isAllowInvalidName()) || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     public static <T> T validate(T object, String message, Object... values) {
@@ -159,6 +164,4 @@ public class ACFBungeeUtil {
         }
         return object;
     }
-
-
 }

--- a/core/src/main/java/co/aikar/commands/CommandManager.java
+++ b/core/src/main/java/co/aikar/commands/CommandManager.java
@@ -75,6 +75,7 @@ public abstract class CommandManager<
     protected CommandHelpFormatter helpFormatter = new CommandHelpFormatter(this);
 
     protected boolean usePerIssuerLocale = false;
+    protected boolean allowInvalidName = false;
     protected List<IssuerLocaleChangedCallback<I>> localeChangedCallbacks = new ArrayList<>();
     protected Set<Locale> supportedLanguages = new HashSet<>(Arrays.asList(Locales.ENGLISH, Locales.DUTCH, Locales.GERMAN, Locales.SPANISH, Locales.FRENCH, Locales.CZECH, Locales.PORTUGUESE, Locales.SWEDISH, Locales.NORWEGIAN_BOKMAAL, Locales.NORWEGIAN_NYNORSK, Locales.RUSSIAN, Locales.BULGARIAN, Locales.HUNGARIAN, Locales.TURKISH, Locales.JAPANESE, Locales.CHINESE, Locales.SIMPLIFIED_CHINESE, Locales.TRADITIONAL_CHINESE, Locales.KOREAN));
     protected Map<MessageType, MF> formatters = new IdentityHashMap<>();
@@ -270,6 +271,16 @@ public abstract class CommandManager<
     public boolean usePerIssuerLocale(boolean setting) {
         boolean old = usePerIssuerLocale;
         usePerIssuerLocale = setting;
+        return old;
+    }
+
+    public boolean isAllowInvalidName() {
+        return allowInvalidName;
+    }
+
+    public boolean allowInvalidName(boolean setting) {
+        boolean old = allowInvalidName;
+        allowInvalidName = setting;
         return old;
     }
 

--- a/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
+++ b/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
@@ -89,8 +89,12 @@ public class ACFSpongeUtil {
         return matchedPlayers;
     }
 
-    public static boolean isValidName(String name, CommandManager manager) {
-        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
+    @Deprecated
+    public static boolean isValidName(String name) {
+        return isValidName(name, null);
     }
 
+    public static boolean isValidName(String name, CommandManager manager) {
+        return name != null && !name.isEmpty() && ((manager != null && manager.isAllowInvalidName()) || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
+    }
 }

--- a/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
+++ b/sponge/src/main/java/co/aikar/commands/ACFSpongeUtil.java
@@ -31,7 +31,7 @@ public class ACFSpongeUtil {
         }
 
         if (matches.isEmpty()) {
-            if (!isValidName(name)) {
+            if (!isValidName(name, issuer.getManager())) {
                 issuer.sendError(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
                 return null;
             }
@@ -89,8 +89,8 @@ public class ACFSpongeUtil {
         return matchedPlayers;
     }
 
-    public static boolean isValidName(String name) {
-        return name != null && !name.isEmpty() && ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches();
+    public static boolean isValidName(String name, CommandManager manager) {
+        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
 }

--- a/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
+++ b/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
@@ -64,8 +64,13 @@ public class ACFVelocityUtil {
                 .collect(Collectors.toList());
     }
 
+    @Deprecated
+    public static boolean isValidName(String name) {
+        return isValidName(name, null);
+    }
+
     public static boolean isValidName(String name, CommandManager manager) {
-        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
+        return name != null && !name.isEmpty() && ((manager != null && manager.isAllowInvalidName()) || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     public static <T> T validate(T object, String message, Object... values) {

--- a/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
+++ b/velocity/src/main/java/co/aikar/commands/ACFVelocityUtil.java
@@ -32,7 +32,7 @@ public class ACFVelocityUtil {
         }
 
         if (matches.isEmpty()) {
-            if (!isValidName(name)) {
+            if (!isValidName(name, issuer.getManager())) {
                 issuer.sendError(MinecraftMessageKeys.IS_NOT_A_VALID_NAME, "{name}", name);
                 return null;
             }
@@ -64,8 +64,8 @@ public class ACFVelocityUtil {
                 .collect(Collectors.toList());
     }
 
-    public static boolean isValidName(String name) {
-        return name != null && !name.isEmpty() && ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches();
+    public static boolean isValidName(String name, CommandManager manager) {
+        return name != null && !name.isEmpty() && (manager.isAllowInvalidName() || ACFPatterns.VALID_NAME_PATTERN.matcher(name).matches());
     }
 
     public static <T> T validate(T object, String message, Object... values) {


### PR DESCRIPTION
Some servers may have players with "invalid" names, such as geyser with a name prefix.