### PR TITLE
fix Velocity root command not checking for permissions correctly

### DIFF
--- a/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
+++ b/velocity/src/main/java/co/aikar/commands/VelocityRootCommand.java
@@ -94,4 +94,9 @@ public class VelocityRootCommand implements SimpleCommand, RootCommand {
     public CompletableFuture<List<String>> suggestAsync(Invocation invocation) {
         return CompletableFuture.completedFuture(getTabCompletions(manager.getCommandIssuer(invocation.source()), getCommandName(), invocation.arguments()));
     }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        return hasAnyPermission(this.manager.getCommandIssuer(invocation.source()));
+    }
 }


### PR DESCRIPTION
seems like at the time Velocity got implemented here, someone forgot to check the permissions issuer had. 

closes #355