### PR TITLE
No longer suggest input as tab completion

### DIFF
--- a/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
+++ b/paper/src/main/java/co/aikar/commands/PaperAsyncTabCompleteHandler.java
@@ -77,6 +77,7 @@ class PaperAsyncTabCompleteHandler implements Listener {
 
         BukkitCommandIssuer issuer = this.manager.getCommandIssuer(sender);
         List<String> completions = rootCommand.getTabCompletions(issuer, commandLabel, args, false, async);
+        completions.removeAll(Arrays.asList(args));
 
         return ACFUtil.preformOnImmutable(existingCompletions, (list) -> list.addAll(completions));
     }


### PR DESCRIPTION
This PR fixes ACF giving the players input back as a tab-complete suggestion.

Previously:
![image](https://github.com/user-attachments/assets/bb5a7a84-4ff5-4ed9-937f-d5d61ac04cec)
Expected was to only receive 'skull' right here, as that's the only registered `@Subcommand`

After:
![image](https://github.com/user-attachments/assets/c10a223a-838b-4722-86fe-64a9c68d13d3)
No suggestion is given, and it auto-fills to the correct subcommand.

I'm not entirely sure what the impact of this is, as I only started using the framework 2 days ago. But I'm more than happy to receive feedback.