### PR TITLE
Open ACFPatterns class to be public

### DIFF
--- a/core/src/main/java/co/aikar/commands/ACFPatterns.java
+++ b/core/src/main/java/co/aikar/commands/ACFPatterns.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 @SuppressWarnings("WeakerAccess")
-final class ACFPatterns {
+public final class ACFPatterns {
     public static final Pattern COMMA = Pattern.compile(",");
     public static final Pattern PERCENTAGE = Pattern.compile("%", Pattern.LITERAL);
     public static final Pattern NEWLINE = Pattern.compile("\n");


### PR DESCRIPTION
While coding my plugin, I find myself having to re-compile many of the patterns that is already provided by ACFPatterns. Thus I think it makes sense to make the class public for usage outside just ACF.