### PR TITLE
Use PlayerLocaleChangeEvent instead of repeating task when available

### DIFF
--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitLocalesListener.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitLocalesListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2025 Daniel Ennis (Aikar) - MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package co.aikar.commands;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLocaleChangeEvent;
+
+import java.util.Locale;
+
+class ACFBukkitLocalesListener implements Listener {
+
+    private final BukkitCommandManager manager;
+
+    ACFBukkitLocalesListener(BukkitCommandManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    void onLocaleChange(PlayerLocaleChangeEvent event) {
+        if (!manager.autoDetectFromClient) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Locale locale = null;
+        try {
+            locale = event.locale();
+        } catch (NoSuchMethodError ignored) {
+            if (!event.getLocale().equals(manager.issuersLocaleString.get(player.getUniqueId()))) {
+                locale = ACFBukkitUtil.stringToLocale(event.getLocale());
+            }
+        }
+        if (locale == null) {
+            return;
+        }
+        manager.issuersLocaleString.put(player.getUniqueId(), locale.toString());
+        manager.setPlayerLocale(player, locale);
+    }
+}

--- a/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
+++ b/bukkit/src/main/java/co/aikar/commands/ACFBukkitUtil.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -325,5 +326,10 @@ public class ACFBukkitUtil {
 
     static boolean isValidItem(ItemStack item) {
         return item != null && item.getType() != Material.AIR && item.getAmount() > 0;
+    }
+
+    public static Locale stringToLocale(String locale) {
+        String[] split = ACFPatterns.UNDERSCORE.split(locale);
+        return split.length > 1 ? new Locale(split[0], split[1]) : new Locale(split[0]);
     }
 }


### PR DESCRIPTION
Use PlayerLocaleChangeEvent for newer versions of minecraft instead of polling all players every few second to see if their locale has changed. This will be a slight performance improvement as player usually dont change locale that often and will very inefficient to keep polling. The polling method will still be kept as a fallback for older minecraft version where PlayerLocaleChangeEvent is not present.