### PR TITLE
Fix instantiate subclass if constructor parameter is the command's type

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -287,7 +287,7 @@ public abstract class BaseCommand {
 
                         declaredConstructor.setAccessible(true);
                         Parameter[] parameters = declaredConstructor.getParameters();
-                        if (parameters.length == 1) {
+                        if (parameters.length == 1 && parameters[0].getType().isAssignableFrom(this.getClass())) {
                             subScope = (BaseCommand) declaredConstructor.newInstance(this);
                         } else {
                             manager.log(LogLevel.INFO, "Found unusable constructor: " + declaredConstructor.getName() + "(" + Stream.of(parameters).map(p -> p.getType().getSimpleName() + " " + p.getName()).collect(Collectors.joining("<c2>,</c2> ")) + ")");


### PR DESCRIPTION
I have my own subclass within an ACF command for my own use, but ACF will try to instantiate them as long as its only has 1 constructor parameter even if it doesn't related to adding a subcommand. So I added a isAssignableFrom check for the correct parameter type before ACF should try to instantiate.

```
[11:32:06 WARN]: java.lang.IllegalArgumentException: argument type mismatch
[11:32:06 WARN]: 	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:65)
[11:32:06 WARN]: 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
[11:32:06 WARN]: 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.acf.commands.BaseCommand.registerSubclasses(BaseCommand.java:291)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.acf.commands.BaseCommand.onRegister(BaseCommand.java:259)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.acf.commands.BaseCommand.onRegister(BaseCommand.java:228)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.acf.commands.BukkitCommandManager.registerCommand(BukkitCommandManager.java:233)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.acf.commands.BukkitCommandManager.registerCommand(BukkitCommandManager.java:266)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.core.MultiverseCore.lambda$registerCommands$9(MultiverseCore.java:204)
[11:32:06 WARN]: 	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.core.MultiverseCore.lambda$registerCommands$10(MultiverseCore.java:201)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.vavr.control.Try.andThenTry(Try.java:250)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.core.MultiverseCore.registerCommands(MultiverseCore.java:200)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.core.MultiverseCore.lambda$onEnable$0(MultiverseCore.java:116)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.external.vavr.control.Try.andThenTry(Try.java:309)
[11:32:06 WARN]: 	at multiverse-core-local.jar//org.mvplugins.multiverse.core.MultiverseCore.onEnable(MultiverseCore.java:111)
[11:32:06 WARN]: 	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:280)
[11:32:06 WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202)
[11:32:06 WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109)
[11:32:06 WARN]: 	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520)
[11:32:06 WARN]: 	at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:657)
[11:32:06 WARN]: 	at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:606)
[11:32:06 WARN]: 	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:743)
[11:32:06 WARN]: 	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:488)
[11:32:06 WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:322)
[11:32:06 WARN]: 	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1163)
[11:32:06 WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
[11:32:06 WARN]: 	at java.base/java.lang.Thread.run(Thread.java:1583)
[11:32:06 WARN]: Caused by: java.lang.ClassCastException: Cannot cast org.mvplugins.multiverse.core.commands.ConfirmCommand to org.mvplugins.multiverse.core.command.MVCommandManager
[11:32:06 WARN]: 	at java.base/java.lang.Class.cast(Class.java:4067)
[11:32:06 WARN]: 	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
[11:32:06 WARN]: 	... 27 more
```