### PR TITLE
Make LogLevel enum public to allow overriding of log method in CommandManager

### DIFF
--- a/core/src/main/java/co/aikar/commands/LogLevel.java
+++ b/core/src/main/java/co/aikar/commands/LogLevel.java
@@ -23,7 +23,7 @@
 
 package co.aikar.commands;
 
-enum LogLevel {
+public enum LogLevel {
     INFO,
     ERROR;
 


### PR DESCRIPTION
I was trying to override the log method in CommandManager to use my our logger class instead. However, the LogLevel enum in the method's parameter is not public. I think it doesn't make sense to have a public method with parameter types that are package-private.