### PR TITLE
BaseCommand should only fulfill tab complete of its own scope

### DIFF
--- a/core/src/main/java/co/aikar/commands/BaseCommand.java
+++ b/core/src/main/java/co/aikar/commands/BaseCommand.java
@@ -643,6 +643,9 @@ public abstract class BaseCommand {
             final List<String> cmds = new ArrayList<>();
             if (search != null) {
                 for (RegisteredCommand<?> command : search.commands) {
+                    if (command.scope != this) {
+                        continue;
+                    }
                     cmds.addAll(completeCommand(issuer, command, search.args, commandLabel, isAsync));
                 }
             }


### PR DESCRIPTION
Fixes #438

There seems to be a weird logic issue where `RootCommand::getTabCompletions` loops through all its possible `BaseCommand` that are related to it. Then, the `BaseCommand::tabComplete` is called, which searches for the `RegisteredCommand` that is related to the command input, regardless of what the `BaseCommand` is. This is then weird because every single `BaseCommand::tabComplete` will now parse tab completion based on the entire command tree. This means every single call of `BaseCommand::tabComplete` from `RootCommand::getTabCompletions` will just be a duplicate of each other. 

My current solution is just to add a simple scope check, but a deeper rethink of the logic flow itself may be needed.