### PR TITLE
Expose command args in completion context

### DIFF
--- a/core/src/main/java/co/aikar/commands/CommandCompletionContext.java
+++ b/core/src/main/java/co/aikar/commands/CommandCompletionContext.java
@@ -123,6 +123,10 @@ public class CommandCompletionContext<I extends CommandIssuer> {
         return input;
     }
 
+    public List<String> getArgs() {
+        return args;
+    }
+
     public String getConfig() {
         return config;
     }


### PR DESCRIPTION
Sometimes information about previous args are needed to generate the current arg's tab completion. This is especially the case for args marked as `@ConsumeRest` or its `String[]` at the end. Hence, I think it's useful to expose the full command args so far for tab completion.